### PR TITLE
Use unpkg.com to get maplibre-gl.js and maplibre-gl.css

### DIFF
--- a/docs/components/urls.js
+++ b/docs/components/urls.js
@@ -1,11 +1,11 @@
-import { version } from '../../mapbox-gl-js/package.json';
+import { version } from '../../maplibre-gl-js/package.json';
 import { prefixUrl } from '@mapbox/batfish/modules/prefix-url';
 
 function url(ext, options) {
     if (options && options.local && process.env.DEPLOY_ENV === 'local') {
-        return prefixUrl(`/dist/mapbox-gl.${ext}`);
+        return prefixUrl(`/dist/maplibre-gl.${ext}`);
     } else {
-        return `https://api.mapbox.com/mapbox-gl-js/v${version}/mapbox-gl.${ext}`;
+        return `https://unpkg.com/maplibre-gl@${version}/dist/maplibre-gl.${ext}`;
     }
 }
 


### PR DESCRIPTION
Makes the docs website get ```maplibre-gl.js``` and ```maplibre-gl.css``` from unpkg.com.