### PR TITLE
Continuous integration and deployment

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1,0 +1,26 @@
+name: build-test-deploy
+
+on: 
+  push:
+    branches:
+    - main
+
+jobs:
+  build-test-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - run: npm ci
+    - run: git submodule update --init
+    - run: npm run build
+    - run: npm run test
+    - run: cp _config.yml _site 
+    - name: Deploy
+      uses: JamesIves/github-pages-deploy-action@4.1.0
+      with:
+        branch: gh-pages
+        folder: _site

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,20 @@
+name: build-test
+
+on: 
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - run: npm ci
+    - run: git submodule update --init
+    - run: npm run build
+    - run: npm run test

--- a/docs/data/__tests__/__snapshots__/api-navigation.test.js.snap
+++ b/docs/data/__tests__/__snapshots__/api-navigation.test.js.snap
@@ -716,6 +716,11 @@ Array [
         "text": "KeyboardHandler",
       },
       Object {
+        "level": 3,
+        "slug": "keyboardhandler-instance-members",
+        "text": "Instance members",
+      },
+      Object {
         "level": 2,
         "slug": "doubleclickzoomhandler",
         "text": "DoubleClickZoomHandler",


### PR DESCRIPTION
This pull requests adds two GitHub Actions workflows:

 * ```build-test``` which builds and tests the repo upon pull request to ```main```
 * ```build-test-deploy``` which builds, tests, and deploys the documentation website to GitHub Pages on push to ```main```.

One test snapshot for ```api-navigation``` was not properly updated, which is fixed with commit 5dc725a.

To deploy to the gh-pages branch I use [this](https://github.com/JamesIves/github-pages-deploy-action) action from the marketplace which seems to work well.
