### PR TITLE
Replace Mapbox with MapLibre and mapbox with maplibre

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Mapbox GL JS Documentation
+# MapLibre GL JS Documentation
 
-The source code for the website that hosts [API documentation](#writing-api-documentation) and [examples](#writing-examples) for [Mapbox GL JS](https://github.com/mapbox/mapbox-gl-js).
+The source code for the website that hosts [API documentation](#writing-api-documentation) and [examples](#writing-examples) for [MapLibre GL JS](https://github.com/maplibre/maplibre-gl-js).
 
 ## Requirements
 
@@ -15,15 +15,15 @@ After cloning this repository, run:
 
 ```bash
 npm ci # install dependencies with npm
-git submodule update --init # initialize mapbox-gl-js git submodule
+git submodule update --init # initialize maplibre-gl-js git submodule
 ```
 
-When pulling in new commits that change the `mapbox-gl-js` submodule,
+When pulling in new commits that change the `maplibre-gl-js` submodule,
 run `git submodule update` to update the local copy as well.
 
 ## Writing API Documentation
 
-API documentation is written as [JSDoc comments](http://usejsdoc.org/) and processed with [documentationjs](http://documentation.js.org/) **in the source code of [mapbox-gl-js](https://github.com/mapbox/mapbox-gl-js)**. This repository fetches the source code through a git submodule.
+API documentation is written as [JSDoc comments](http://usejsdoc.org/) and processed with [documentationjs](http://documentation.js.org/) **in the source code of [maplibre-gl-js](https://github.com/maplibre/maplibre-gl-js)**. This repository fetches the source code through a git submodule.
 
 * Classes, methods, events, and anything else in the public interface must be documented with JSDoc comments. Everything outside of the public interface may be documented and must be tagged as `@private`.
 * Text within JSDoc comments may use markdown formatting. Code identifiers must be surrounded by \`backticks\`.
@@ -75,12 +75,12 @@ The command will print the URL you can use to view the documentation.
 
 💡 If you receive an error related to `@mapbox/appropriate-images`, try `nvm use && npm start`.
 
-The examples section of the locally run documentation will use the GL JS version located in `../mapbox-gl-js/dist`,
-so make sure to have a working minified build in your local copy of the `mapbox-gl-js` repo (not the submodule).
+The examples section of the locally run documentation will use the GL JS version located in `../maplibre-gl-js/dist`,
+so make sure to have a working minified build in your local copy of the `maplibre-gl-js` repo (not the submodule).
 
 ## Committing and Publishing Documentation
 
-When a new GL JS release goes out, the release manager will make a PR that updates this repo's `mapbox-gl-js` submodule to point to the new release. When updating the submodule, you may need to run `npm test -- -u` to update Jest snapshots related to the sidebar navigation.
+When a new GL JS release goes out, the release manager will make a PR that updates this repo's `maplibre-gl-js` submodule to point to the new release. When updating the submodule, you may need to run `npm test -- -u` to update Jest snapshots related to the sidebar navigation.
 
 To update or add a new example, PR the relevant changes to this repo. The example will be live once the PR is merged.  If this example uses a version of GL JS that isn't yet released, the PR should not be merged until the release is out.
 


### PR DESCRIPTION
This pull requests updates the README.md file where it replaces ```Mapbox``` with ```MapLibre``` and ```mapbox``` with ```maplibre```.