### PR TITLE
Migrate example simple map

### DIFF
--- a/docs/pages/example/simple-map.html
+++ b/docs/pages/example/simple-map.html
@@ -1,8 +1,9 @@
 <div id="map"></div>
 <script>
-    var map = new mapboxgl.Map({
+    var map = new maplibregl.Map({
         container: 'map', // container id
-        style: 'mapbox://styles/mapbox/streets-v11', // style URL
+        style:
+            'https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL', // style URL
         center: [-74.5, 40], // starting position [lng, lat]
         zoom: 9 // starting zoom
     });

--- a/docs/pages/example/simple-map.md
+++ b/docs/pages/example/simple-map.md
@@ -1,6 +1,6 @@
 ---
 title: Display a map
-description: Initialize a map in an HTML element with Mapbox GL JS.
+description: Initialize a map in an HTML element with MapLibre GL JS.
 topics:
   - Getting started
   - Styles
@@ -10,12 +10,12 @@ layout: example
 language:
 - JavaScript
 products:
-- Mapbox GL JS
+- MapLibre GL JS
 prependJs:
 - "import Example from '../../components/example';"
 - "import html from './simple-map.html';"
 ---
 
-Initialize a map in an HTML element with Mapbox GL JS.
+Initialize a map in an HTML element with MapLibre GL JS.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/simple-map.md
+++ b/docs/pages/example/simple-map.md
@@ -10,7 +10,7 @@ layout: example
 language:
 - JavaScript
 products:
-- MapLibre GL JS
+- Mapbox GL JS
 prependJs:
 - "import Example from '../../components/example';"
 - "import html from './simple-map.html';"


### PR DESCRIPTION
This pull request migrates the ```simple-map``` example, which serves as the hello world example on the front page, to MapLibre GL JS. We use maptiler (thanks to Petr Pridal @klokan) as a tile source for this with the api key specified in https://github.com/maplibre/maplibre-gl-js-docs/issues/2.