### PR TITLE
Update logo link in top left corner to www.maplibre.org

### DIFF
--- a/vendor/docs-page-shell/react-page-shell.js
+++ b/vendor/docs-page-shell/react-page-shell.js
@@ -366,8 +366,8 @@ function Logo(props) {
   return React.createElement("div", {
     className: "shell-flex-parent shell-flex-parent--center-cross"
   }, React.createElement("a", {
-    href: "https://www.mapbox.com",
-    "aria-label": "Mapbox",
+    href: "https://www.maplibre.org",
+    "aria-label": "MapLibre",
     className: logoClasses,
     style: logoStyles
   }), border, React.createElement("a", {


### PR DESCRIPTION
This pull requests updates the link under the logo in the top left corner of the page to https://www.maplibre.org.