### PR TITLE
Allow maplibregl in examples by updating the linter configuration

### DIFF
--- a/docs/pages/example/.eslintrc
+++ b/docs/pages/example/.eslintrc
@@ -12,6 +12,7 @@
     },
     "plugins": ["html"],
     "globals": {
+      "maplibregl": true,
       "mapboxgl": true,
       "MapboxGeocoder": true,
       "MapboxDirections": true,


### PR DESCRIPTION
This pull request updates the linter rules such that we can have for example ```var map = new maplibregl.Map()``` in the example files and pass all the tests.