### PR TITLE
Add MapLibre to @mapbox/copyeditor config file

### DIFF
--- a/local.dic
+++ b/local.dic
@@ -25,3 +25,4 @@ CJK
 fullscreen
 Taya
 Lavrinenko's
+MapLibre


### PR DESCRIPTION
This pull request adds ```MapLibre``` to the configuration file of @mapbox/copyeditor, which is a tool for spell checking the example markdown files.