### PR TITLE
Migrate example batch 1

### DIFF
--- a/docs/pages/example/3d-buildings.html
+++ b/docs/pages/example/3d-buildings.html
@@ -1,7 +1,8 @@
 <div id="map"></div>
 <script>
-    var map = new mapboxgl.Map({
-        style: 'mapbox://styles/mapbox/light-v10',
+    var map = new maplibregl.Map({
+        style:
+            'https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL',
         center: [-74.0066, 40.7135],
         zoom: 15.5,
         pitch: 45,
@@ -10,7 +11,7 @@
         antialias: true
     });
 
-    // The 'building' layer in the mapbox-streets vector source contains building-height
+    // The 'building' layer in the streets vector source contains building-height
     // data from OpenStreetMap.
     map.on('load', function () {
         // Insert the layer beneath any symbol layer.

--- a/docs/pages/example/3d-buildings.md
+++ b/docs/pages/example/3d-buildings.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './3d-buildings.html';"
 ---
 
-Use [extrusions](/maplibre-gl-js-docs/style-spec/layers/#fill-extrusion) to display buildings' height in 3D.
+Use [extrusions](https://maplibre.org/maplibre-gl-js-docs/style-spec/layers/#fill-extrusion) to display buildings' height in 3D.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/3d-buildings.md
+++ b/docs/pages/example/3d-buildings.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './3d-buildings.html';"
 ---
 
-Use [extrusions](/mapbox-gl-js/style-spec#layers-fill-extrusion) to display buildings' height in 3D.
+Use [extrusions](/maplibre-gl-js-docs/style-spec/layers/#fill-extrusion) to display buildings' height in 3D.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/3d-extrusion-floorplan.html
+++ b/docs/pages/example/3d-extrusion-floorplan.html
@@ -1,8 +1,9 @@
 <div id="map"></div>
 <script>
-    var map = new mapboxgl.Map({
+    var map = new maplibregl.Map({
         container: 'map',
-        style: 'mapbox://styles/mapbox/streets-v11',
+        style:
+            'https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL',
         center: [-87.61694, 41.86625],
         zoom: 15.99,
         pitch: 40,

--- a/docs/pages/example/3d-extrusion-floorplan.md
+++ b/docs/pages/example/3d-extrusion-floorplan.md
@@ -15,6 +15,6 @@ prependJs:
 - "import html from './3d-extrusion-floorplan.html';"
 ---
 
-Create a 3D indoor map with the [`fill-extrude-height`](/maplibre-gl-js-docs/style-spec/layers/#paint-fill-extrusion-fill-extrusion-height) paint property.
+Create a 3D indoor map with the [`fill-extrude-height`](https://maplibre.org/maplibre-gl-js-docs/style-spec/layers/#paint-fill-extrusion-fill-extrusion-height) paint property.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/3d-extrusion-floorplan.md
+++ b/docs/pages/example/3d-extrusion-floorplan.md
@@ -15,6 +15,6 @@ prependJs:
 - "import html from './3d-extrusion-floorplan.html';"
 ---
 
-Create a 3D indoor map with the [`fill-extrude-height`](/mapbox-gl-js/style-spec/layers/#paint-fill-extrusion-fill-extrusion-height) paint property.
+Create a 3D indoor map with the [`fill-extrude-height`](/maplibre-gl-js-docs/style-spec/layers/#paint-fill-extrusion-fill-extrusion-height) paint property.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/add-a-marker.html
+++ b/docs/pages/example/add-a-marker.html
@@ -1,14 +1,15 @@
 <div id="map"></div>
 
 <script>
-    var map = new mapboxgl.Map({
+    var map = new maplibregl.Map({
         container: 'map',
-        style: 'mapbox://styles/mapbox/streets-v11',
+        style:
+            'https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL',
         center: [12.550343, 55.665957],
         zoom: 8
     });
 
-    var marker = new mapboxgl.Marker()
+    var marker = new maplibregl.Marker()
         .setLngLat([12.550343, 55.665957])
         .addTo(map);
 </script>

--- a/docs/pages/example/add-a-marker.md
+++ b/docs/pages/example/add-a-marker.md
@@ -15,6 +15,6 @@ prependJs:
 - "import html from './add-a-marker.html';"
 ---
 
-Add a default [`Marker`](/mapbox-gl-js/api/markers/#marker) to the map.
+Add a default [`Marker`](/maplibre-gl-js-docs/api/markers/#marker) to the map.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/add-a-marker.md
+++ b/docs/pages/example/add-a-marker.md
@@ -15,6 +15,6 @@ prependJs:
 - "import html from './add-a-marker.html';"
 ---
 
-Add a default [`Marker`](/maplibre-gl-js-docs/api/markers/#marker) to the map.
+Add a default [`Marker`](https://maplibre.org/maplibre-gl-js-docs/api/markers/#marker) to the map.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/add-image-animated.html
+++ b/docs/pages/example/add-image-animated.html
@@ -1,15 +1,16 @@
 <div id="map"></div>
 
 <script>
-    var map = new mapboxgl.Map({
+    var map = new maplibregl.Map({
         container: 'map',
-        style: 'mapbox://styles/mapbox/streets-v9'
+        style:
+            'https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL'
     });
 
     var size = 200;
 
     // implementation of CustomLayerInterface to draw a pulsing dot icon on the map
-    // see https://docs.mapbox.com/mapbox-gl-js/api/#customlayerinterface for more info
+    // see https://maplibre.org/maplibre-gl-js-docs/api/properties/#customlayerinterface for more info
     var pulsingDot = {
         width: size,
         height: size,


### PR DESCRIPTION
This pull request migrates 4 examples from mapbox to maplibre with maptiler streets as the vector data source.

I had to use full URLs in the markdown files as otherwise I would get the following linter error:

```
docs/pages/example/add-a-marker.md
18:15-18:67  error  Link to https://docs.mapbox.com/maplibre-gl-js-docs/api/markers/#marker is dead
link-checker-skip-external  remark-lint-mapbox
```