### PR TITLE
Add migration note to README.md and the frontpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The source code for the website that hosts [API documentation](#writing-api-documentation) and [examples](#writing-examples) for [MapLibre GL JS](https://github.com/maplibre/maplibre-gl-js).
 
+## Migration Note
+
+We are now migrating this documentation from Mapbox to MapLibre. If you want to contribute feel free to open an [issue](https://github.com/maplibre/maplibre-gl-js-docs/issues) on GitHub or submit a [pull request](https://github.com/maplibre/maplibre-gl-js-docs/pulls) to propose directly your changes.
+
 ## Requirements
 
 * Node 12

--- a/docs/pages/api/index.md
+++ b/docs/pages/api/index.md
@@ -31,6 +31,11 @@ overviewHeader:
 Mapbox GL JS is a JavaScript library that uses WebGL to render interactive maps from [vector tiles](https://docs.mapbox.com/help/glossary/vector-tiles/) and [Mapbox styles](/mapbox-gl-js/style-spec/). It is part of the Mapbox GL ecosystem, which includes [Mapbox Mobile](https://www.mapbox.com/mobile/), a compatible renderer written in C++ with bindings for desktop and mobile platforms.
 
 
+## Migration Note
+
+We are now migrating this documentation from Mapbox to MapLibre. If you want to contribute feel free to open an [issue](https://github.com/maplibre/maplibre-gl-js-docs/issues) on GitHub or submit a [pull request](https://github.com/maplibre/maplibre-gl-js-docs/pulls) to propose directly your changes.
+
+
 ## Quickstart
 
 {{


### PR DESCRIPTION
This pull request adds a note about the migration from Mapbox to MapLibre to the readme and the front website.

I find that something like this is needed because there is some confusion about the status of the docs website, seen https://github.com/maplibre/maplibre-gl-js/discussions/69.

Feel free to change the wording.