### PR TITLE
Hide feedback button in examples

### DIFF
--- a/docs/pages/example/3d-buildings.md
+++ b/docs/pages/example/3d-buildings.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: 3d-buildings
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/3d-extrusion-floorplan.md
+++ b/docs/pages/example/3d-extrusion-floorplan.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: 3d-extrusion-floorplan
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/add-3d-model.md
+++ b/docs/pages/example/add-3d-model.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: add-3d-model
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/add-a-marker.md
+++ b/docs/pages/example/add-a-marker.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: add-a-marker
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/add-image-animated.md
+++ b/docs/pages/example/add-image-animated.md
@@ -7,6 +7,7 @@ topics:
 thumbnail: add-image-animated
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/add-image-generated.md
+++ b/docs/pages/example/add-image-generated.md
@@ -7,6 +7,7 @@ topics:
 thumbnail: add-image-generated
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/add-image-missing-generated.md
+++ b/docs/pages/example/add-image-missing-generated.md
@@ -7,6 +7,7 @@ topics:
 thumbnail: add-image-missing-generated
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/add-image-stretchable.md
+++ b/docs/pages/example/add-image-stretchable.md
@@ -7,6 +7,7 @@ topics:
 thumbnail: add-image-stretchable
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/add-image.md
+++ b/docs/pages/example/add-image.md
@@ -7,6 +7,7 @@ topics:
 thumbnail: add-image
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/animate-a-line.md
+++ b/docs/pages/example/animate-a-line.md
@@ -7,6 +7,7 @@ topics:
 thumbnail: animate-a-line
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/animate-camera-around-point.md
+++ b/docs/pages/example/animate-camera-around-point.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: animate-camera-around-point
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/animate-images.md
+++ b/docs/pages/example/animate-images.md
@@ -7,6 +7,7 @@ topics:
 thumbnail: animate-images
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/animate-marker.md
+++ b/docs/pages/example/animate-marker.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: animate-marker
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/animate-point-along-line.md
+++ b/docs/pages/example/animate-point-along-line.md
@@ -7,6 +7,7 @@ topics:
 thumbnail: animate-point-along-line
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/animate-point-along-route.md
+++ b/docs/pages/example/animate-point-along-route.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: animate-point-along-route
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/attribution-position.md
+++ b/docs/pages/example/attribution-position.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: attribution-position
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/camera-animation.md
+++ b/docs/pages/example/camera-animation.md
@@ -7,6 +7,7 @@ topics:
 thumbnail: camera-animation
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/canvas-source.md
+++ b/docs/pages/example/canvas-source.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: canvas-source
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/center-on-symbol.md
+++ b/docs/pages/example/center-on-symbol.md
@@ -7,6 +7,7 @@ topics:
 thumbnail: center-on-symbol
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/change-building-color-based-on-zoom-level.md
+++ b/docs/pages/example/change-building-color-based-on-zoom-level.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: change-building-color-based-on-zoom-level
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/change-case-of-labels.md
+++ b/docs/pages/example/change-case-of-labels.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: change-case-of-labels
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/check-for-support.md
+++ b/docs/pages/example/check-for-support.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: check-for-support
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/cluster-html.md
+++ b/docs/pages/example/cluster-html.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: cluster-html
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/cluster.md
+++ b/docs/pages/example/cluster.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: cluster
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/color-switcher.md
+++ b/docs/pages/example/color-switcher.md
@@ -7,6 +7,7 @@ topics:
 thumbnail: color-switcher
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/custom-marker-icons.md
+++ b/docs/pages/example/custom-marker-icons.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: custom-marker-icons
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/custom-style-layer.md
+++ b/docs/pages/example/custom-style-layer.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: custom-style-layer
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/data-driven-lines.md
+++ b/docs/pages/example/data-driven-lines.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: data-driven-lines
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/disable-rotation.md
+++ b/docs/pages/example/disable-rotation.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: disable-rotation
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/disable-scroll-zoom.md
+++ b/docs/pages/example/disable-scroll-zoom.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: disable-scroll-zoom
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/display-and-style-rich-text-labels.md
+++ b/docs/pages/example/display-and-style-rich-text-labels.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: display-and-style-rich-text-labels
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/drag-a-marker.md
+++ b/docs/pages/example/drag-a-marker.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: drag-a-marker
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/drag-a-point.md
+++ b/docs/pages/example/drag-a-point.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: drag-a-point
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/fallback-image.md
+++ b/docs/pages/example/fallback-image.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: fallback-image
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/fill-pattern.md
+++ b/docs/pages/example/fill-pattern.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: fill-pattern
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/filter-markers-by-input.md
+++ b/docs/pages/example/filter-markers-by-input.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: filter-markers-by-input
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/filter-markers.md
+++ b/docs/pages/example/filter-markers.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: filter-markers
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/fitbounds.md
+++ b/docs/pages/example/fitbounds.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: fitbounds
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/flyto-options.md
+++ b/docs/pages/example/flyto-options.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: flyto-options
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/flyto.md
+++ b/docs/pages/example/flyto.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: flyto
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/fullscreen.md
+++ b/docs/pages/example/fullscreen.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: fullscreen
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/game-controls.md
+++ b/docs/pages/example/game-controls.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: game-controls
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/geojson-layer-in-stack.md
+++ b/docs/pages/example/geojson-layer-in-stack.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: geojson-layer-in-stack
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/geojson-line.md
+++ b/docs/pages/example/geojson-line.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: geojson-line
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/geojson-markers.md
+++ b/docs/pages/example/geojson-markers.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: geojson-markers
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/geojson-polygon.md
+++ b/docs/pages/example/geojson-polygon.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: geojson-polygon
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/heatmap-layer.md
+++ b/docs/pages/example/heatmap-layer.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: heatmap-layer
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/hover-styles.md
+++ b/docs/pages/example/hover-styles.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: hover-styles
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/index.md
+++ b/docs/pages/example/index.md
@@ -3,6 +3,7 @@ title: Examples
 description: Code examples for Mapbox GL JS.
 contentType: example
 layout: example
+hideFeedback: true
 navOrder: 2
 language:
 - JavaScript

--- a/docs/pages/example/interactive-false.md
+++ b/docs/pages/example/interactive-false.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: interactive-false
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/jump-to.md
+++ b/docs/pages/example/jump-to.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: jump-to
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/language-switch.md
+++ b/docs/pages/example/language-switch.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: language-switch
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/line-across-180th-meridian.md
+++ b/docs/pages/example/line-across-180th-meridian.md
@@ -6,6 +6,7 @@ topics:
   - Layers
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/line-gradient.md
+++ b/docs/pages/example/line-gradient.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: line-gradient
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/live-geojson.md
+++ b/docs/pages/example/live-geojson.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: live-geojson
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/live-update-feature.md
+++ b/docs/pages/example/live-update-feature.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: live-update-feature
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/local-ideographs.md
+++ b/docs/pages/example/local-ideographs.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: local-ideographs
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/locate-user.md
+++ b/docs/pages/example/locate-user.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: locate-user
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/map-tiles.md
+++ b/docs/pages/example/map-tiles.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: map-tiles
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/mapbox-gl-draw.md
+++ b/docs/pages/example/mapbox-gl-draw.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: mapbox-gl-draw
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/mapbox-gl-rtl-text.md
+++ b/docs/pages/example/mapbox-gl-rtl-text.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: mapbox-gl-rtl-text
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/measure.md
+++ b/docs/pages/example/measure.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: measure
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/mouse-position.md
+++ b/docs/pages/example/mouse-position.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: mouse-position
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/multiple-geometries.md
+++ b/docs/pages/example/multiple-geometries.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: multiple-geometries
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/navigation.md
+++ b/docs/pages/example/navigation.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: navigation
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/offset-vanishing-point-with-padding.md
+++ b/docs/pages/example/offset-vanishing-point-with-padding.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: offset-vanishing-point-with-padding
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/polygon-popup-on-click.md
+++ b/docs/pages/example/polygon-popup-on-click.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: polygon-popup-on-click
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/popup-on-click.md
+++ b/docs/pages/example/popup-on-click.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: popup-on-click
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/popup-on-hover.md
+++ b/docs/pages/example/popup-on-hover.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: popup-on-hover
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/popup.md
+++ b/docs/pages/example/popup.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: popup
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/queryrenderedfeatures.md
+++ b/docs/pages/example/queryrenderedfeatures.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: queryrenderedfeatures
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/render-world-copies.md
+++ b/docs/pages/example/render-world-copies.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: render-world-copies
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/restrict-bounds.md
+++ b/docs/pages/example/restrict-bounds.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: restrict-bounds
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/satellite-map.md
+++ b/docs/pages/example/satellite-map.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: satellite-map
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/scroll-fly-to.md
+++ b/docs/pages/example/scroll-fly-to.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: scroll-fly-to
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/set-perspective.md
+++ b/docs/pages/example/set-perspective.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: set-perspective
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/set-popup.md
+++ b/docs/pages/example/set-popup.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: set-popup
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/simple-map.md
+++ b/docs/pages/example/simple-map.md
@@ -7,6 +7,7 @@ topics:
 thumbnail: simple-map
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/third-party.md
+++ b/docs/pages/example/third-party.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: third-party
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/timeline-animation.md
+++ b/docs/pages/example/timeline-animation.md
@@ -7,6 +7,7 @@ topics:
 thumbnail: timeline-animation
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/toggle-interaction-handlers.md
+++ b/docs/pages/example/toggle-interaction-handlers.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: toggle-interaction-handlers
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/variable-label-placement.md
+++ b/docs/pages/example/variable-label-placement.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: variable-label-placement
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/vector-source.md
+++ b/docs/pages/example/vector-source.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: vector-source
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/video-on-a-map.md
+++ b/docs/pages/example/video-on-a-map.md
@@ -7,6 +7,7 @@ topics:
 thumbnail: video-on-a-map
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/visualize-population-density.md
+++ b/docs/pages/example/visualize-population-density.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: visualize-population-density
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/wms.md
+++ b/docs/pages/example/wms.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: wms
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:

--- a/docs/pages/example/zoomto-linestring.md
+++ b/docs/pages/example/zoomto-linestring.md
@@ -6,6 +6,7 @@ topics:
 thumbnail: zoomto-linestring
 contentType: example
 layout: example
+hideFeedback: true
 language:
 - JavaScript
 products:


### PR DESCRIPTION
This pull requests adds ```hideFeedback: true``` to all the example markdown files which hides the feedback button.