### PR TITLE
Migrate links in style-spec/expressions to the maplibre examples

### DIFF
--- a/docs/data/expressions-related.json
+++ b/docs/data/expressions-related.json
@@ -2,297 +2,219 @@
   "!": [
     {
       "title": "Create and style clusters",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/cluster/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/cluster/"
     }
   ],
   "!=": [
     {
       "title": "Display HTML clusters with custom properties",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/cluster-html/"
-    }
-  ],
-  "-": [
-    {
-      "title": "Get started with Mapbox GL JS expressions: Calculate the age of each landmark",
-      "href": "https://docs.mapbox.com/help/tutorials/mapbox-gl-js-expressions/#calculate-the-age-of-each-landmark"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/cluster-html/"
     }
   ],
   "/": [
     {
-      "title": "Get started with Mapbox GL JS expressions: Adjust the circle radius",
-      "href": "https://docs.mapbox.com/help/tutorials/mapbox-gl-js-expressions/#adjust-the-circle-radius"
-    },
-    {
       "title": "Visualize population density",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/visualize-population-density/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/visualize-population-density/"
     }
   ],
   "<": [
     {
       "title": "Display HTML clusters with custom properties",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/cluster-html/"
-    }
-  ],
-  "<=": [
-    {
-      "title": "Animate 3D buildings based on ambient sounds",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/dancing-buildings/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/cluster-html/"
     }
   ],
   "==": [
     {
       "title": "Add multiple geometries from one GeoJSON source",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/multiple-geometries/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/multiple-geometries/"
     },
     {
       "title": "Create a time slider",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/timeline-animation/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/timeline-animation/"
     },
     {
       "title": "Display buildings in 3D",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/3d-buildings/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/3d-buildings/"
     },
     {
       "title": "Filter symbols by toggling a list",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/filter-markers/"
-    }
-  ],
-  ">": [
-    {
-      "title": "Animate 3D buildings based on ambient sounds",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/dancing-buildings/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/filter-markers/"
     }
   ],
   ">=": [
     {
       "title": "Display HTML clusters with custom properties",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/cluster-html/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/cluster-html/"
     }
   ],
   "all": [
     {
-      "title": "Add an image",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/image-on-a-map/"
-    },
-    {
-      "title": "Animate 3D buildings based on ambient sounds",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/dancing-buildings/"
-    },
-    {
-      "title": "Change worldview of administrative boundaries",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/toggle-worldviews/"
-    },
-    {
       "title": "Display HTML clusters with custom properties",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/cluster-html/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/cluster-html/"
     }
   ],
   "boolean": [
     {
       "title": "Create a hover effect",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/hover-styles/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/hover-styles/"
     }
   ],
   "case": [
     {
       "title": "Create a hover effect",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/hover-styles/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/hover-styles/"
     },
     {
       "title": "Display HTML clusters with custom properties",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/cluster-html/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/cluster-html/"
     }
   ],
   "coalesce": [
     {
       "title": "Use a fallback image",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/fallback-image/"
-    },
-    {
-      "title": "Video: Add bilingual labels to a map with expressions in Studio",
-      "href": "https://docs.mapbox.com/help/tutorials/add-bilingual-labels-to-a-map-using-expressions-video/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/fallback-image/"
     }
   ],
   "concat": [
     {
       "title": "Add a generated icon to the map",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/add-image-missing-generated/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/add-image-missing-generated/"
     },
     {
       "title": "Create a time slider",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/timeline-animation/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/timeline-animation/"
     },
     {
       "title": "Use a fallback image",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/fallback-image/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/fallback-image/"
     },
     {
       "title": "Variable label placement",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/variable-label-placement/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/variable-label-placement/"
     }
   ],
   "downcase": [
     {
       "title": "Change the case of labels",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/change-case-of-labels/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/change-case-of-labels/"
     }
   ],
   "feature-state": [
     {
       "title": "Create a hover effect",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/hover-styles/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/hover-styles/"
     }
   ],
   "format": [
     {
       "title": "Change the case of labels",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/change-case-of-labels/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/change-case-of-labels/"
     },
     {
       "title": "Display and style rich text labels",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/display-and-style-rich-text-labels/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/display-and-style-rich-text-labels/"
     },
     {
       "title": "Display buildings in 3D",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/3d-buildings/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/3d-buildings/"
     }
   ],
   "get": [
     {
       "title": "Change the case of labels",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/change-case-of-labels/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/change-case-of-labels/"
     },
     {
       "title": "Display HTML clusters with custom properties",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/cluster-html/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/cluster-html/"
     },
     {
       "title": "Extrude polygons for 3D indoor mapping",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/3d-extrusion-floorplan/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/3d-extrusion-floorplan/"
     }
   ],
   "has": [
     {
       "title": "Create and style clusters",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/cluster/"
-    },
-    {
-      "title": "Filter features within map view",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/filter-features-within-map-view/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/cluster/"
     }
   ],
   "image": [
     {
       "title": "Use a fallback image",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/fallback-image/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/fallback-image/"
     }
   ],
   "in": [
     {
-      "title": "Get features under the mouse pointer",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/queryrenderedfeatures-around-point/"
-    },
-    {
-      "title": "Highlight features containing similar data",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/query-similar-features/"
-    },
-    {
-      "title": "Highlight features within a bounding box",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/"
-    },
-    {
       "title": "Measure distances",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/measure/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/measure/"
     }
   ],
   "interpolate": [
     {
       "title": "Animate map camera around a point",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/animate-camera-around-point/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/animate-camera-around-point/"
     },
     {
       "title": "Change building color based on zoom level",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/change-building-color-based-on-zoom-level/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/change-building-color-based-on-zoom-level/"
     },
     {
       "title": "Create a heatmap layer",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/heatmap-layer/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/heatmap-layer/"
     },
     {
       "title": "Visualize population density",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/visualize-population-density/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/visualize-population-density/"
     }
   ],
   "let": [
     {
       "title": "Visualize population density",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/visualize-population-density/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/visualize-population-density/"
     }
   ],
   "literal": [
     {
       "title": "Display and style rich text labels",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/display-and-style-rich-text-labels/"
-    }
-  ],
-  "match": [
-    {
-      "title": "Change worldview of administrative boundaries",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/toggle-worldviews/"
-    },
-    {
-      "title": "Filter features within map view",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/filter-features-within-map-view/"
-    },
-    {
-      "title": "Join local JSON data with vector tile geometries",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/data-join/"
-    },
-    {
-      "title": "Style circles with a data-driven property",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/data-driven-circle-colors/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/display-and-style-rich-text-labels/"
     }
   ],
   "number-format": [
     {
       "title": "Display HTML clusters with custom properties",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/cluster-html/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/cluster-html/"
     }
   ],
   "step": [
     {
       "title": "Create and style clusters",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/cluster/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/cluster/"
     }
   ],
   "to-color": [
     {
       "title": "Visualize population density",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/visualize-population-density/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/visualize-population-density/"
     }
   ],
   "to-string": [
     {
       "title": "Create a time slider",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/timeline-animation/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/timeline-animation/"
     }
   ],
   "upcase": [
     {
       "title": "Change the case of labels",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/change-case-of-labels/"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/change-case-of-labels/"
     }
   ],
   "var": [
     {
       "title": "Visualize population density",
-      "href": "https://docs.mapbox.com/mapbox-gl-js/example/visualize-population-density/"
-    }
-  ],
-  "zoom": [
-    {
-      "title": "Get started with Mapbox GL JS expressions: Add a zoom expression",
-      "href": "https://docs.mapbox.com/help/tutorials/mapbox-gl-js-expressions/#add-a-zoom-expression"
+      "href": "https://maplibre.org/maplibre-gl-js-docs/example/visualize-population-density/"
     }
   ]
 }


### PR DESCRIPTION
This pull request migrates the links that appear in the **Related** section of the style-spec [expressions page](https://maplibre.org/maplibre-gl-js-docs/style-spec/expressions/) from ```mapbox``` to ```maplibre```. 

Links to examples that have not been migrated are removed. Links to mapbox.com tutorials are removed as well.

Expressions that have no associated link are removed from ```expressions-related.json``` as otherwise the page would show the **Related** heading but no link below.