### PR TITLE
Clean-up deployment information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MapLibre GL JS Documentation
 
-The source code for https://maplibre.org/maplibre-gl-js-docs/, the website that hosts [API documentation](#writing-api-documentation) and [examples](#writing-examples) for [MapLibre GL JS](https://github.com/maplibre/maplibre-gl-js).
+The source code for https://maplibre.org/maplibre-gl-js-docs/, the website that hosts [API documentation](#writing-api-documentation) and [examples](#writing-examples) for [MapLibre GL JS](https://github.com/maplibre/maplibre-gl-js). A GitHub Actions Workflow is triggered on push to the ```main``` branch. This Action builds the static website and deploys it to GitHub Pages by pushing to the ```gh-pages``` branch.
 
 ## Migration Note
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MapLibre GL JS Documentation
 
-The source code for the website that hosts [API documentation](#writing-api-documentation) and [examples](#writing-examples) for [MapLibre GL JS](https://github.com/maplibre/maplibre-gl-js).
+The source code for https://maplibre.org/maplibre-gl-js-docs/, the website that hosts [API documentation](#writing-api-documentation) and [examples](#writing-examples) for [MapLibre GL JS](https://github.com/maplibre/maplibre-gl-js).
 
 ## Migration Note
 
@@ -87,14 +87,3 @@ so make sure to have a working minified build in your local copy of the `maplibr
 When a new GL JS release goes out, the release manager will make a PR that updates this repo's `maplibre-gl-js` submodule to point to the new release. When updating the submodule, you may need to run `npm test -- -u` to update Jest snapshots related to the sidebar navigation.
 
 To update or add a new example, PR the relevant changes to this repo. The example will be live once the PR is merged.  If this example uses a version of GL JS that isn't yet released, the PR should not be merged until the release is out.
-
-## Deploy to GitHub Pages
-
-After building the documentation with ```npm run build``` the static site files are located in ```_site```. 
-
-Publish the build output to GitHub Pages at [https://maplibre.github.io/maplibre-gl-js-docs/](https://maplibre.github.io/maplibre-gl-js-docs/) with:
-
-```bash
-npm install -g gh-pages
-npm run deploy
-```

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "prebuild": "npm run build-docs",
     "prestart": "npm run build-docs",
     "build": "batfish build",
-    "deploy": "cp _config.yml _site && gh-pages -d _site",
     "serve-static": "batfish serve-static",
     "pretest": "npm run lint",
     "test": "tape test/*.test.js | tap-min && npm run lint-md && npm run test-content && jest",


### PR DESCRIPTION
This pull request adds a link to the documentation website at the beginning of the readme and removes outdated information about manual deployment to GitHub pages - for this we have actions now.