### PR TITLE
Maplibre style spec

### DIFF
--- a/batfish.config.js
+++ b/batfish.config.js
@@ -50,7 +50,7 @@ module.exports = () => {
                 use: 'raw-loader'
             },
             {
-                test: /@mapbox\/mapbox-gl-style-spec\/expression\/definitions\/index.js$/,
+                test: /@maplibre\/maplibre-gl-style-spec\/expression\/definitions\/index.js$/,
                 sideEffects: true
             }
         ],
@@ -90,7 +90,7 @@ module.exports = () => {
         devBrowserslist: false,
         babelInclude: [
             'documentation',
-            '@mapbox/mapbox-gl-style-spec',
+            '@maplibre/maplibre-gl-style-spec',
             'fuse.js'
         ],
         webpackStaticIgnore: [/util\/util\.js$/]

--- a/docs/components/__tests__/expression-metadata.test.js
+++ b/docs/components/__tests__/expression-metadata.test.js
@@ -1,9 +1,9 @@
 import { types } from '../expression-metadata';
-import ref from '@mapbox/mapbox-gl-style-spec/reference/latest';
+import ref from '@maplibre/maplibre-gl-style-spec/reference/latest';
 
 // help us catch that every type in expression-metadata.js exists in the style-spec
 // otherwise the site will not build
-describe('expression-metadata.js type exists in mapbox-gl-js-style-spec', () => {
+describe('expression-metadata.js type exists in maplibre-gl-js-style-spec', () => {
     for (const name in types) {
         it(name, () => {
             expect(ref['expression_name'].values[name]).not.toBeUndefined();
@@ -13,7 +13,7 @@ describe('expression-metadata.js type exists in mapbox-gl-js-style-spec', () => 
 
 // help us catch expressions we need to add to expression-metadata.js during version bumps
 // otherwise the definition/type will not be added to the site
-describe('mapbox-gl-js-style-spec expression appears in expression-metadata.js', () => {
+describe('maplibre-gl-js-style-spec expression appears in expression-metadata.js', () => {
     for (let name in ref['expression_name'].values) {
         if (!/^filter-/.test(name) && name !== 'error') {
             it(name, () => {

--- a/docs/components/expression-metadata.js
+++ b/docs/components/expression-metadata.js
@@ -1,8 +1,8 @@
-import { toString } from '@mapbox/mapbox-gl-style-spec/expression/types';
-import CompoundExpression from '@mapbox/mapbox-gl-style-spec/expression/compound_expression';
+import { toString } from '@maplibre/maplibre-gl-style-spec/expression/types';
+import CompoundExpression from '@maplibre/maplibre-gl-style-spec/expression/compound_expression';
 
 // registers compound expressions
-import '@mapbox/mapbox-gl-style-spec/expression/definitions/index';
+import '@maplibre/maplibre-gl-style-spec/expression/definitions/index';
 
 const comparisonSignatures = [
     {

--- a/docs/components/expressions.js
+++ b/docs/components/expressions.js
@@ -1,4 +1,4 @@
-import ref from '@mapbox/mapbox-gl-style-spec/reference/latest';
+import ref from '@maplibre/maplibre-gl-style-spec/reference/latest';
 import { types } from './expression-metadata';
 
 export const expressions = {};

--- a/docs/components/page-shell.js
+++ b/docs/components/page-shell.js
@@ -30,7 +30,7 @@ import { devDependencies } from '../../package.json';
 import slug from 'slugg';
 
 const styleSpecVersion = devDependencies[
-    '@mapbox/mapbox-gl-style-spec'
+    '@maplibre/maplibre-gl-style-spec'
 ].replace('^', '');
 
 const redirectStyleSpec = require('../util/style-spec-redirect');

--- a/docs/data/style-spec-navigation.js
+++ b/docs/data/style-spec-navigation.js
@@ -1,6 +1,6 @@
 import entries from 'object.entries';
 import slug from 'slugg';
-import ref from '@mapbox/mapbox-gl-style-spec/reference/latest';
+import ref from '@maplibre/maplibre-gl-style-spec/reference/latest';
 import { layerTypes, groupedExpressions } from './types';
 
 /*

--- a/docs/pages/style-spec/glyphs.md
+++ b/docs/pages/style-spec/glyphs.md
@@ -9,7 +9,7 @@ hideFeedback: true
 products:
 - Mapbox Style Specification
 prependJs:
-    - "import ref from '@mapbox/mapbox-gl-style-spec/reference/latest';"
+    - "import ref from '@maplibre/maplibre-gl-style-spec/reference/latest';"
 ---
 
 <!--copyeditor disable basic-->

--- a/docs/pages/style-spec/layers.md
+++ b/docs/pages/style-spec/layers.md
@@ -12,7 +12,7 @@ prependJs:
     - "import Items from '../../components/style-spec/items';"
     - "import { layerTypes } from '../../data/types';"
     - "import combineItems from '../../util/combine-items';"
-    - "import ref from '@mapbox/mapbox-gl-style-spec/reference/latest';"
+    - "import ref from '@maplibre/maplibre-gl-style-spec/reference/latest';"
     - "import AppropriateImage from '../../components/appropriate-image';"
     - "import Caption from '../../components/caption';"
 ---

--- a/docs/pages/style-spec/light.md
+++ b/docs/pages/style-spec/light.md
@@ -10,7 +10,7 @@ products:
 - Mapbox Style Specification
 prependJs:
     - "import Items from '../../components/style-spec/items';"
-    - "import ref from '@mapbox/mapbox-gl-style-spec/reference/latest';"
+    - "import ref from '@maplibre/maplibre-gl-style-spec/reference/latest';"
 ---
 
 A style's `light` property provides a global light source for that style. Since this property is the light used to light extruded features, you will only see visible changes to your map style when modifying this property if you are using extrusions.

--- a/docs/pages/style-spec/other.md
+++ b/docs/pages/style-spec/other.md
@@ -10,7 +10,7 @@ products:
 - Mapbox Style Specification
 prependJs:
     - "import SDKSupportTable from '../../components/sdk_support_table';"
-    - "import ref from '@mapbox/mapbox-gl-style-spec/reference/latest';"
+    - "import ref from '@maplibre/maplibre-gl-style-spec/reference/latest';"
     - "import Icon from '@mapbox/mr-ui/icon';"
     - "import Property from '../../components/style-spec/property.js';"
     - "import Subtitle from '../../components/style-spec/subtitle.js';"

--- a/docs/pages/style-spec/root.md
+++ b/docs/pages/style-spec/root.md
@@ -10,7 +10,7 @@ products:
 - Mapbox Style Specification
 prependJs:
     - "import Items from '../../components/style-spec/items';"
-    - "import ref from '@mapbox/mapbox-gl-style-spec/reference/latest';"
+    - "import ref from '@maplibre/maplibre-gl-style-spec/reference/latest';"
 ---
 
 Root level properties of a Mapbox style specify the map's layers, tile sources and other resources, and default values for the initial camera position when not specified elsewhere.

--- a/docs/pages/style-spec/sources.md
+++ b/docs/pages/style-spec/sources.md
@@ -12,7 +12,7 @@ prependJs:
     - "import Items from '../../components/style-spec/items';"
     - "import { sourceTypes } from '../../data/types';"
     - "import SDKSupportTable from '../../components/sdk_support_table';"
-    - "import ref from '@mapbox/mapbox-gl-style-spec/reference/latest';"
+    - "import ref from '@maplibre/maplibre-gl-style-spec/reference/latest';"
 ---
 
 <!--copyeditor disable basic-->

--- a/docs/pages/style-spec/sprite.md
+++ b/docs/pages/style-spec/sprite.md
@@ -9,7 +9,7 @@ hideFeedback: true
 products:
 - Mapbox Style Specification
 prependJs:
-    - "import ref from '@mapbox/mapbox-gl-style-spec/reference/latest';"
+    - "import ref from '@maplibre/maplibre-gl-style-spec/reference/latest';"
 ---
 
 A style's `sprite` property supplies a URL template for loading small images to use in rendering `background-pattern`, `fill-pattern`, `line-pattern`,`fill-extrusion-pattern` and `icon-image` style properties.

--- a/docs/pages/style-spec/transition.md
+++ b/docs/pages/style-spec/transition.md
@@ -10,7 +10,7 @@ products:
 - Mapbox Style Specification
 prependJs:
     - "import Items from '../../components/style-spec/items';"
-    - "import ref from '@mapbox/mapbox-gl-style-spec/reference/latest';"
+    - "import ref from '@maplibre/maplibre-gl-style-spec/reference/latest';"
     - "import Icon from '@mapbox/mr-ui/icon';"
 ---
 

--- a/docs/util/combine-items.js
+++ b/docs/util/combine-items.js
@@ -1,4 +1,4 @@
-import ref from '@mapbox/mapbox-gl-style-spec/reference/latest';
+import ref from '@maplibre/maplibre-gl-style-spec/reference/latest';
 
 // helper function to:
 // combine properties, prepare them, and sort them for the <Items /> component

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "mapbox-gl-js-docs",
+  "name": "maplibre-gl-js-docs",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
@@ -585,12 +585,20 @@
       }
     },
     "@babel/plugin-syntax-flow": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.12.1.tgz",
-      "integrity": "sha512-1lBLLmtxrwpm4VKmtVFselI/P3pX+G63fAtUUt6b2Nzgao77KNDwyuRt90Mj2/9pKobtt68FdvjfqohZjg/FCA==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.12.13.tgz",
+      "integrity": "sha512-J/RYxnlSLXZLVR7wTRsozxKT8qbsx1mNKJzXEEjQ0Kjx1ZACcyHgbanNWNCFtc36IzuWhYWPpvJFFoexoOWFmA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+          "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-syntax-function-bind": {
@@ -821,13 +829,21 @@
       }
     },
     "@babel/plugin-transform-flow-strip-types": {
-      "version": "7.12.10",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.12.10.tgz",
-      "integrity": "sha512-0ti12wLTLeUIzu9U7kjqIn4MyOL7+Wibc7avsHhj4o1l5C0ATs8p2IMHrVYjm9t9wzhfEO6S3kxax0Rpdo8LTg==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.13.0.tgz",
+      "integrity": "sha512-EXAGFMJgSX8gxWD7PZtW/P6M+z74jpx3wm/+9pn+c2dOawPpBkUX7BrfyPvo6ZpXbgRIEuwgwDb/MGlKvu2pOg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-flow": "^7.12.1"
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-flow": "^7.12.13"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+          "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-transform-for-of": {
@@ -1176,13 +1192,28 @@
       }
     },
     "@babel/preset-flow": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.12.1.tgz",
-      "integrity": "sha512-UAoyMdioAhM6H99qPoKvpHMzxmNVXno8GYU/7vZmGaHk6/KqfDYL1W0NxszVbJ2EP271b7e6Ox+Vk2A9QsB3Sw==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.13.13.tgz",
+      "integrity": "sha512-MDtwtamMifqq3R2mC7l3A3uFalUb3NH5TIBQWjN/epEPlZktcLq4se3J+ivckKrLMGsR7H9LW8+pYuIUN9tsKg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-transform-flow-strip-types": "^7.12.1"
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-validator-option": "^7.12.17",
+        "@babel/plugin-transform-flow-strip-types": "^7.13.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+          "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+          "dev": true
+        },
+        "@babel/helper-validator-option": {
+          "version": "7.12.17",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+          "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+          "dev": true
+        }
       }
     },
     "@babel/preset-modules": {
@@ -3130,22 +3161,6 @@
       "integrity": "sha512-KwqOLogwEQKghRMSNfIPC4GoCcaxngXocopNzhv7INoGmYMRY079zNNyStiOLL00aVY4p5sSVUKsJFt9/f34Tg==",
       "dev": true
     },
-    "@mapbox/mapbox-gl-style-spec": {
-      "version": "13.18.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.18.1.tgz",
-      "integrity": "sha512-By+CufXEpba7sIUfnpbtVzy5tqrCyFDNssq1k7psxzCL1Xr0y916OSkEH0j7fFilhalVExjoh/mYtxH32tOYqw==",
-      "dev": true,
-      "requires": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/unitbezier": "^0.0.0",
-        "csscolorparser": "~1.0.2",
-        "json-stringify-pretty-compact": "^2.0.0",
-        "minimist": "^1.2.5",
-        "rw": "^1.3.3",
-        "sort-object": "^0.3.2"
-      }
-    },
     "@mapbox/mapbox-gl-supported": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
@@ -3335,6 +3350,22 @@
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
       "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4=",
       "dev": true
+    },
+    "@maplibre/maplibre-gl-style-spec": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-14.0.0.tgz",
+      "integrity": "sha512-88wrbUhL8ybbAVP0wjU3sSWanl2GOEFEIWVwyOFbFSULSLLyyq1v3pAFnFDIrWgQZJ4j91gj2v8clwTe/glM1A==",
+      "dev": true,
+      "requires": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/unitbezier": "^0.0.0",
+        "csscolorparser": "~1.0.2",
+        "json-stringify-pretty-compact": "^2.0.0",
+        "minimist": "^1.2.5",
+        "rw": "^1.3.3",
+        "sort-object": "^0.3.2"
+      }
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@mapbox/dr-ui": "^2.2.0",
     "@mapbox/eslint-config-docs": "0.7.0",
     "@mapbox/eslint-config-mapbox": "^3.0.0",
-    "@mapbox/mapbox-gl-style-spec": "^13.15.0",
     "@mapbox/mapbox-gl-supported": "^1.5.0",
     "@mapbox/mbx-assembly": "^0.29.0",
     "@mapbox/mr-ui": "^0.9.1",
@@ -31,6 +30,7 @@
     "@mapbox/remark-config-docs": "^0.8.0",
     "@mapbox/remark-lint-link-text": "^0.5.0",
     "@mapbox/remark-lint-mapbox": "^2.2.0",
+    "@maplibre/maplibre-gl-style-spec": "^14.0.0",
     "@sentry/browser": "^5.27.4",
     "babel-eslint": "^10.1.0",
     "check-links": "^1.1.8",
@@ -105,7 +105,7 @@
       "/maplibre-gl-js/"
     ],
     "transformIgnorePatterns": [
-      "/node_modules\\/(?!(mapbox-gl-style-spec))/"
+      "/node_modules\\/(?!(maplibre-gl-style-spec))/"
     ],
     "testRegex": "/__tests__/.*\\.test\\.js$"
   }


### PR DESCRIPTION
This pull request works towards replacing `@mapbox/mapbox-gl-style-spec` with `@maplibre/maplibre-gl-style-spec`. Currently this fails with

```
 [19:05:57 Batfish] Error: Webpack compilation error.

./node_modules/@maplibre/maplibre-gl-style-spec/expression/types.js 3:7
Module parse failed: Unexpected token (3:7)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
| // @flow
| 
> export type NullTypeT = { kind: 'null' };
| export type NumberTypeT = { kind: 'number' };
| export type StringTypeT = { kind: 'string' };
```