### PR TITLE
Corrected the source in the 3d buildings example to match the style source

### DIFF
--- a/docs/pages/example/3d-buildings.html
+++ b/docs/pages/example/3d-buildings.html
@@ -28,7 +28,7 @@
         map.addLayer(
             {
                 'id': '3d-buildings',
-                'source': 'composite',
+                'source': 'openmaptiles',
                 'source-layer': 'building',
                 'filter': ['==', 'extrude', 'true'],
                 'type': 'fill-extrusion',


### PR DESCRIPTION
This addresses issue https://github.com/maplibre/maplibre-gl-js/issues/152

The source is changed from composite to openmaptiles, as can be seen when searching for the source in https://api.maptiler.com/maps/streets/style.json

This fixes the problem visible in the console at runtime for the 3d buildings example:
evented.js:140 Error: layers.3d-buildings: source "composite" not found
    at Object.Bn [as emitValidationErrors] (validate_style.js:37)
    at Ue (style.js:46)
    at i._validate (style.js:1211)
    at i.addLayer (style.js:677)
    at r.addLayer (map.js:1888)
    at r.<anonymous> ((index):4665)
    at r.Ct.fire (evented.js:119)
    at r._render (map.js:2511)
    at map.js:2629
