### PR TITLE
Batfish only run in my case after deleting the dist folder

### DIFF
--- a/docs/pages/dist
+++ b/docs/pages/dist
@@ -1,1 +1,0 @@
-../../../maplibre-gl-js/dist


### PR DESCRIPTION
I had problems installing the repo. After deleting the `dist` folder, everything worked.

```
[09:14:31 Batfish] Development server ready.
  > Access your site at http://localhost:8080/maplibre-gl-js-docs/
  > Available externally at http://192.168.209.132:8080/maplibre-gl-js-docs/
  > Compiled files are in _site
[09:14:31 Batfish] Webpack compiled in 4m 2.3s
[09:14:39 Batfish] Webpack compiled in 5.3s
...
```

When I reactivated the dist folder via` git stash`, the error message appeared again and Batfish died.

```
...
Error: ENOENT: no such file or directory, stat '/home/astrid/git/maplibre/maplibre-gl-js-docs/docs/pages/dist'
$ /git/maplibre/maplibre-gl-js-docs$ nvm use && npm start

```

I am working on Ubuntu 20.04 with npm 7.6.1. amd node 10.23.0.

Is it possible that there is a problem with permissions? Where exactly is the directory needed?
