### PR TITLE
Do not use node package for creating remark config any more -> so we can exclude check for proudct,

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -1,12 +1,50 @@
-const rc = require('@mapbox/remark-config-docs');
 const topicsOrder = require('./docs/data/topics.json');
 
-const config = {
-    siteBasePath: 'maplibre-gl-js-docs',
-    pages: 'docs/pages/',
-    constants: 'docs/constants.json',
-    ignoreLinks: 'conf/ignore-links.json',
-    topicOptions: topicsOrder
-};
+const config = [
+    ['@mapbox/remark-lint-link-text', [2]],
+    ['remark-lint-heading-increment', [2]],
+    [
+        '@mapbox/remark-lint-mapbox/link-checker/skip-internal',
+        [
+            1,
+            {
+                siteBasePath: 'maplibre-gl-js-docs',
+                pages: 'docs/pages/',
+                constants: 'docs/constants.json',
+                ignoreLinks: 'conf/ignore-links.json'
+            }
+        ]
+    ],
+    [
+        '@mapbox/remark-lint-mapbox/link-checker/skip-external',
+        [
+            1,
+            {
+                siteBasePath: 'maplibre-gl-js-docs',
+                pages: 'docs/pages/',
+                constants: 'docs/constants.json',
+                ignoreLinks: 'conf/ignore-links.json'
+            }
+        ]
+    ],
+    [
+        '@mapbox/remark-lint-mapbox/constantly',
+        [
+            2,
+            {
+                constants: 'docs/constants.json'
+            }
+        ]
+    ],
+    ['remark-frontmatter', ['yaml']],
+    [
+        '@mapbox/remark-lint-mapbox/frontmatter',
+        {
+            disableProducts: true,
+            topicOptions: topicsOrder
+        }
+    ],
+    ['@mapbox/remark-lint-mapbox/xtreme', [2]]
+];
 
-exports.plugins = [...rc.plugins(config)];
+exports.plugins = [...config];

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@mapbox/mbx-assembly": "^0.29.0",
     "@mapbox/mr-ui": "^0.9.1",
     "@mapbox/prettier-config-docs": "^0.2.1",
-    "@mapbox/remark-config-docs": "^0.8.0",
     "@mapbox/remark-lint-link-text": "^0.5.0",
     "@mapbox/remark-lint-mapbox": "^2.2.0",
     "@maplibre/maplibre-gl-style-spec": "^14.0.0",


### PR DESCRIPTION
Because of the `remark` configuration we can not use Maplibre as `product `name . I stumbled across this in https://github.com/maplibre/maplibre-gl-js-docs/pull/58. It is not possible to use `Maplibre GL JS` in https://github.com/maplibre/maplibre-gl-js-docs/pull/58/files#diff-604664e92c63ab379a8bdf863252857482ffd1f642e3cdd4223985ad9ca8a705 as `product `name. 


Thereby we would have the possibility to overwrite this via parameter.
Unfortunately, this ist not possible in our repositiory, if we use the package [remark-config-docs](https://www.npmjs.com/package/@mapbox/remark-config-docs) for creating the configuration.

Therefore, I removed the package [remark-config-docs] (https://www.npmjs.com/package/@mapbox/remark-config-docs) and added the same configuration statically.

A static implementation is not the best, I know. But this way 
- we make `Maplibre docs` one package more independent.
-  We can change the static file more easily if we want to adapt other remark rules. (Later, we can build a solution that suits us.)
- Now we can use our own product name.

What do you think?

