### PR TITLE
Update submodule to maplibre-gl-js v1.15.0

### DIFF
--- a/docs/data/__tests__/__snapshots__/api-navigation.test.js.snap
+++ b/docs/data/__tests__/__snapshots__/api-navigation.test.js.snap
@@ -812,11 +812,6 @@ Array [
         "text": "Instance members",
       },
       Object {
-        "level": 3,
-        "slug": "imagesource-related",
-        "text": "Related",
-      },
-      Object {
         "level": 2,
         "slug": "canvassource",
         "text": "CanvasSource",


### PR DESCRIPTION
This pull request brings the docs website to the latest release of maplibre-gl-js: `v1.15.0`.

![image](https://user-images.githubusercontent.com/53421382/124360554-d1b57780-dc2a-11eb-9971-6de70126a5ed.png)
