### PR TITLE
Receive release-maplibre-gl-js event

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - main
+  repository_dispatch:
+    types: [release-maplibre-gl-js]
 
 jobs:
   build-test-deploy:


### PR DESCRIPTION
This change should trigger the `build-test-deploy` workflow when a `release-maplibre-gl-js` event is received. The event is being dispatched by the [`release` workflow of maplibre/maplibre-gl-js](https://github.com/maplibre/maplibre-gl-js/actions/workflows/release.yml)