### PR TITLE
Add workflow to automatically generate pull requests for the latest MapLibre GL JS version

### DIFF
--- a/.github/workflows/update-gl-js.yml
+++ b/.github/workflows/update-gl-js.yml
@@ -1,0 +1,27 @@
+name: update-gl-js
+
+on: 
+  workflow_dispatch
+
+jobs:
+  update-gl-js:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - run: git config --global user.email "mail@example.com"
+    - run: git config --global user.name "GitHub Action"
+    - run: git checkout -b v$(npm show maplibre-gl version)
+    - run: |
+        cd maplibre-gl-js
+        git pull
+        cd ..
+        git add -u
+        git commit -m "Update MapLibre GL JS to v$(npm show maplibre-gl version)"
+    - run: git push --set-upstream origin v$(npm show maplibre-gl version)
+    - run: gh pr create --base main --fill
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/update-gl-js.yml
+++ b/.github/workflows/update-gl-js.yml
@@ -1,7 +1,9 @@
 name: update-gl-js
 
 on: 
-  workflow_dispatch
+  workflow_dispatch:
+  repository_dispatch:
+    types: [release-maplibre-gl-js]
 
 jobs:
   update-gl-js:

--- a/.github/workflows/update-gl-js.yml
+++ b/.github/workflows/update-gl-js.yml
@@ -14,14 +14,17 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 14.x
-    - run: git config --global user.email "mail@example.com"
-    - run: git config --global user.name "GitHub Action"
+
     - name: Prepare
       id: prepare
       run: |
         echo "::set-output name=version_tag::$(npm show maplibre-gl version)"
-    - run: git checkout -b v${{ steps.prepare.outputs.version_tag }}
-    - run: |
+
+    - name: Update submodule, commit, push
+      run: |
+        git config --global user.email "mail@example.com"
+        git config --global user.name "GitHub Action"
+        git checkout -b v${{ steps.prepare.outputs.version_tag }}
         git submodule update --init
         cd maplibre-gl-js
         git checkout main
@@ -29,7 +32,9 @@ jobs:
         cd ..
         git add -u
         git commit -m "Update MapLibre GL JS to v${{ steps.prepare.outputs.version_tag }}"
-    - run: git push --set-upstream origin v${{ steps.prepare.outputs.version_tag }}
-    - run: gh pr create --base main --fill
-      env:
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        git push --set-upstream origin v${{ steps.prepare.outputs.version_tag }}
+
+    - name: Create pull request
+      run: gh pr create --base main --fill
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/update-gl-js.yml
+++ b/.github/workflows/update-gl-js.yml
@@ -17,6 +17,7 @@ jobs:
     - run: git checkout -b v$(npm show maplibre-gl version)
     - run: |
         cd maplibre-gl-js
+        git checkout main
         git pull
         cd ..
         git add -u

--- a/.github/workflows/update-gl-js.yml
+++ b/.github/workflows/update-gl-js.yml
@@ -16,7 +16,13 @@ jobs:
         node-version: 14.x
     - run: git config --global user.email "mail@example.com"
     - run: git config --global user.name "GitHub Action"
-    - run: git checkout -b v$(npm show maplibre-gl version)
+    - name: Prepare
+      id: prepare
+      run: |
+        $LatestVersionTag=$(npm show maplibre-gl version)
+        echo "Latest version tag=$LatestVersionTag"
+        echo "::set-output name=version_tag::$LatestVersionTag"
+    - run: git checkout -b v${{ steps.prepare.outputs.version_tag }}
     - run: |
         git submodule update --init
         cd maplibre-gl-js
@@ -24,8 +30,8 @@ jobs:
         git pull
         cd ..
         git add -u
-        git commit -m "Update MapLibre GL JS to v$(npm show maplibre-gl version)"
-    - run: git push --set-upstream origin v$(npm show maplibre-gl version)
+        git commit -m "Update MapLibre GL JS to v${{ steps.prepare.outputs.version_tag }}"
+    - run: git push --set-upstream origin v${{ steps.prepare.outputs.version_tag }}
     - run: gh pr create --base main --fill
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/update-gl-js.yml
+++ b/.github/workflows/update-gl-js.yml
@@ -36,5 +36,5 @@ jobs:
 
     - name: Create pull request
       run: gh pr create --base main --fill
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/update-gl-js.yml
+++ b/.github/workflows/update-gl-js.yml
@@ -19,9 +19,7 @@ jobs:
     - name: Prepare
       id: prepare
       run: |
-        $LatestVersionTag=$(npm show maplibre-gl version)
-        echo "Latest version tag=$LatestVersionTag"
-        echo "::set-output name=version_tag::$LatestVersionTag"
+        echo "::set-output name=version_tag::$(npm show maplibre-gl version)"
     - run: git checkout -b v${{ steps.prepare.outputs.version_tag }}
     - run: |
         git submodule update --init

--- a/.github/workflows/update-gl-js.yml
+++ b/.github/workflows/update-gl-js.yml
@@ -16,6 +16,7 @@ jobs:
     - run: git config --global user.name "GitHub Action"
     - run: git checkout -b v$(npm show maplibre-gl version)
     - run: |
+        git submodule update --init
         cd maplibre-gl-js
         git checkout main
         git pull


### PR DESCRIPTION
This pull request adds a GitHub Action which 

* checks out the docs repos, 
* updates the submodule in `maplibre-gl-js` to the latest commit,
* creates a branch named with the new version (e.g. `v1.15.2`), 
* pushes the branch to `maplibre/maplibre-gl-js-docs`, 
* and creates a pull request to merge the new branch into `main`.