### PR TITLE
Test before making a pull request

### DIFF
--- a/.github/workflows/update-gl-js.yml
+++ b/.github/workflows/update-gl-js.yml
@@ -10,26 +10,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 14.x
+    - name: Use Node.js 12.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 12.x
 
     - name: Prepare
       id: prepare
       run: |
         echo "::set-output name=version_tag::$(npm show maplibre-gl version)"
 
-    - name: Update submodule, commit, push
+    - name: Update submodule, test, build, commit, push
       run: |
         git config --global user.email "mail@example.com"
         git config --global user.name "GitHub Action"
         git checkout -b v${{ steps.prepare.outputs.version_tag }}
+        npm ci
         git submodule update --init
         cd maplibre-gl-js
         git checkout main
         git pull
         cd ..
+        npm run build
+        npm run test
         git add -u
         git commit -m "Update MapLibre GL JS to v${{ steps.prepare.outputs.version_tag }}"
         git push --set-upstream origin v${{ steps.prepare.outputs.version_tag }}


### PR DESCRIPTION
Since a workflow cannot trigger another workflow (https://github.community/t/github-actions-workflow-not-triggering-with-tag-push/17053), we will get a pull request with the new version but the `build-test.yml` action does not run:

![image](https://user-images.githubusercontent.com/53421382/125688397-4dc08cf6-e988-4186-a474-91b876aa55e2.png)

(https://github.com/maplibre/maplibre-gl-js-docs/pull/65)

Since I don't want to merge untested code I prefer running the tests before actually making a pull request. This is what this change does.