### PR TITLE
Update language-switch.html

### DIFF
--- a/docs/pages/example/language-switch.html
+++ b/docs/pages/example/language-switch.html
@@ -44,7 +44,7 @@
             // and the new property value.
             map.setLayoutProperty('label_country', 'text-field', [
                 'get',
-                'name_' + language
+                'name:' + language
             ]);
         });
 </script>


### PR DESCRIPTION
Small fix in the language switch demo, using name: (OpenMapTiles) instead of name_  (Mapbox)  makes the switch work for all languages again.