### PR TITLE
Link to map libre style spec consistently

### DIFF
--- a/docs/data/plugins.json
+++ b/docs/data/plugins.json
@@ -122,7 +122,7 @@
     },
     "expression-jamsession": {
       "website": "https://github.com/mapbox/expression-jamsession/",
-      "description": "Converts [Mapbox Studio formulas](https://www.mapbox.com/help/studio-manual-styles/#use-a-formula) into [expressions](https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions)."
+      "description": "Converts [Mapbox Studio formulas](https://www.mapbox.com/help/studio-manual-styles/#use-a-formula) into [expressions](/maplibre-gl-js-docs/style-spec/#expressions)."
     },
     "simplespec-to-gl-style": {
       "website": "https://github.com/mapbox/simplespec-to-gl-style",

--- a/docs/documentation.yml
+++ b/docs/documentation.yml
@@ -72,7 +72,7 @@ toc:
   - name: Sources
     page: 'sources'
     description: |
-      The source types Mapbox GL JS can handle in addition to the ones described in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/).
+      The source types MapLibre GL JS can handle in addition to the ones described in the [MapLibre Style Specification](/maplibre-gl-js-docs/style-spec/).
     children:
       - GeoJSONSource
       - VideoSource


### PR DESCRIPTION
When navigating the docs I ended up accidentally navigating the mapbox docs instead without realising, this was because I clicked a link to the style spec. Updated the links to direct to the map libre style spec pages instead as even though they are currently the same it keeps users within the correct documentation site.