### PR TITLE
Update to MapLibre GL JS after Typescript migration

### DIFF
--- a/docs/data/__tests__/__snapshots__/api-navigation.test.js.snap
+++ b/docs/data/__tests__/__snapshots__/api-navigation.test.js.snap
@@ -64,41 +64,6 @@ Array [
     "subnav": Array [
       Object {
         "level": 2,
-        "slug": "accesstoken",
-        "text": "accessToken",
-      },
-      Object {
-        "level": 3,
-        "slug": "accesstoken-returns",
-        "text": "Returns",
-      },
-      Object {
-        "level": 3,
-        "slug": "accesstoken-example",
-        "text": "Example",
-      },
-      Object {
-        "level": 3,
-        "slug": "accesstoken-related",
-        "text": "Related",
-      },
-      Object {
-        "level": 2,
-        "slug": "baseapiurl",
-        "text": "baseApiUrl",
-      },
-      Object {
-        "level": 3,
-        "slug": "baseapiurl-returns",
-        "text": "Returns",
-      },
-      Object {
-        "level": 3,
-        "slug": "baseapiurl-example",
-        "text": "Example",
-      },
-      Object {
-        "level": 2,
         "slug": "workercount",
         "text": "workerCount",
       },
@@ -249,6 +214,11 @@ Array [
       },
       Object {
         "level": 3,
+        "slug": "paddingoptions-static-members",
+        "text": "Static members",
+      },
+      Object {
+        "level": 3,
         "slug": "paddingoptions-related",
         "text": "Related",
       },
@@ -274,11 +244,6 @@ Array [
       },
       Object {
         "level": 3,
-        "path": "styleimageinterface-properties",
-        "text": "Properties",
-      },
-      Object {
-        "level": 3,
         "slug": "styleimageinterface-example",
         "text": "Example",
       },
@@ -296,11 +261,6 @@ Array [
         "level": 2,
         "slug": "customlayerinterface",
         "text": "CustomLayerInterface",
-      },
-      Object {
-        "level": 3,
-        "path": "customlayerinterface-properties",
-        "text": "Properties",
       },
       Object {
         "level": 3,
@@ -606,8 +566,23 @@ Array [
       },
       Object {
         "level": 3,
+        "slug": "point-parameters",
+        "text": "Parameters",
+      },
+      Object {
+        "level": 3,
         "slug": "point-example",
         "text": "Example",
+      },
+      Object {
+        "level": 3,
+        "slug": "point-static-members",
+        "text": "Static members",
+      },
+      Object {
+        "level": 3,
+        "slug": "point-instance-members",
+        "text": "Instance members",
       },
       Object {
         "level": 2,
@@ -876,16 +851,6 @@ Array [
         "level": 3,
         "slug": "maptouchevent-instance-members",
         "text": "Instance members",
-      },
-      Object {
-        "level": 2,
-        "slug": "mapboxzoomevent",
-        "text": "MapBoxZoomEvent",
-      },
-      Object {
-        "level": 3,
-        "path": "mapboxzoomevent-properties",
-        "text": "Properties",
       },
       Object {
         "level": 2,

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "lint": "eslint --ext .html docs/pages/example --ext .js .",
     "lint-md": "remark docs/pages/",
     "install-gl-js-deps": "cd maplibre-gl-js/ && npm install --ignore-scripts --no-package-lock --no-audit --loglevel=error",
-    "build-api": "documentation build --document-exported --github --format json --sort-order alpha --config ./docs/documentation.yml --output docs/components/api.json maplibre-gl-js/src/index.ts",
+    "build-api": "documentation build --pe ts --re ts --re d.ts --github --format json --sort-order alpha --config ./docs/documentation.yml --output docs/components/api.json maplibre-gl-js/src/index.ts",
     "build-images": "mkdir -p docs/img/dist && node docs/bin/build-image-config.js && node docs/bin/appropriate-images.js --all",
     "build-docs": "run-s install-gl-js-deps build-api build-images",
     "prebuild": "npm run build-docs",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "lint": "eslint --ext .html docs/pages/example --ext .js .",
     "lint-md": "remark docs/pages/",
     "install-gl-js-deps": "cd maplibre-gl-js/ && npm install --ignore-scripts --no-package-lock --no-audit --loglevel=error",
-    "build-api": "documentation build --github --format json --sort-order alpha --config ./docs/documentation.yml --output docs/components/api.json maplibre-gl-js/src/index.js",
+    "build-api": "documentation build --document-exported --github --format json --sort-order alpha --config ./docs/documentation.yml --output docs/components/api.json maplibre-gl-js/src/index.ts",
     "build-images": "mkdir -p docs/img/dist && node docs/bin/build-image-config.js && node docs/bin/appropriate-images.js --all",
     "build-docs": "run-s install-gl-js-deps build-api build-images",
     "prebuild": "npm run build-docs",


### PR DESCRIPTION
~This is work in progress. Feel free to play around.~

This pull request adapts the documentation to MapLibre GL JS after the typescript migration. Only merge this once we publish `v2.0.0` on NPM.