### PR TITLE
added some maplibre and mapbox plugins into docs

### DIFF
--- a/docs/data/plugins.json
+++ b/docs/data/plugins.json
@@ -25,9 +25,13 @@
       "description": "Adds support for drawing and editing features on maps.",
       "example": "mapbox-gl-draw"
     },
-    "mapbox-gl-export": {
-      "website": "https://github.com/watergis/mapbox-gl-export",
-      "description": "Adds a control that exports the map as a PDF or PNG."
+    "mapbox-gl-elevation": {
+      "website": "https://github.com/watergis/mapbox-gl-elevation",
+      "description": "Adds a control to retrieve altitude from terrain RGB tilesets."
+    },
+    "maplibre-gl-export": {
+      "website": "https://github.com/watergis/maplibre-gl-export",
+      "description": "Adds a control that exports the map as a PDF or images such as PNG, JPEG and SVG."
     },
     "mapbox-gl-geocoder": {
       "website": "https://github.com/mapbox/mapbox-gl-geocoder",
@@ -56,6 +60,14 @@
     "maplibre-gl-temporal-control": {
       "website": "https://github.com/Kanahiro/maplibre-gl-temporal-control",
       "description": "Temporal Controller plugin for MapLibre GL JS. [demo](https://kanahiro.github.io/maplibre-gl-temporal-control/raster.html)."
+    },
+    "mapbox-gl-valhalla": {
+      "website": "https://github.com/watergis/mapbox-gl-valhalla",
+      "description": "Adds a control to provide isochrone features from valhalla server."
+    },
+    "mapbox.photon": {
+      "website": "https://github.com/watergis/mapbox.photon",
+      "description": "Adds a control to provide a geocoding feature from Photon API."
     }
   },
   "Map Rendering Plugins": {


### PR DESCRIPTION
I added my mapbox plugins on maplibre documentation. Could you merge them for me?
I have migrated `mapbox-gl-export` to maplibre, however other plugins are not yet shifted. I will update documentation again once I will migrate other plugins to maplibre.

- Changed plugin name from [mapbox-gl-export](https://github.com/watergis/mapbox-gl-export) to [maplibre-gl-export](https://github.com/watergis/maplibre-gl-export)
- added following mapbox plugins.
  - [mapbox-gl-elevation](https://github.com/watergis/mapbox-gl-elevation)
  - [mapbox-gl-valhalla](https://github.com/watergis/mapbox-gl-valhalla)
  - [mapbox.photon](https://github.com/watergis/mapbox.photon)