### PR TITLE
Bump GL JS submodule to v2.0.1 and include `addProtocol`

### DIFF
--- a/docs/data/__tests__/__snapshots__/api-navigation.test.js.snap
+++ b/docs/data/__tests__/__snapshots__/api-navigation.test.js.snap
@@ -119,11 +119,6 @@ Array [
       },
       Object {
         "level": 2,
-        "slug": "version",
-        "text": "version",
-      },
-      Object {
-        "level": 2,
         "slug": "setrtltextplugin",
         "text": "setRTLTextPlugin",
       },
@@ -165,6 +160,36 @@ Array [
       Object {
         "level": 3,
         "slug": "clearstorage-example",
+        "text": "Example",
+      },
+      Object {
+        "level": 2,
+        "slug": "addprotocol",
+        "text": "addProtocol",
+      },
+      Object {
+        "level": 3,
+        "slug": "addprotocol-parameters",
+        "text": "Parameters",
+      },
+      Object {
+        "level": 3,
+        "slug": "addprotocol-example",
+        "text": "Example",
+      },
+      Object {
+        "level": 2,
+        "slug": "removeprotocol",
+        "text": "removeProtocol",
+      },
+      Object {
+        "level": 3,
+        "slug": "removeprotocol-parameters",
+        "text": "Parameters",
+      },
+      Object {
+        "level": 3,
+        "slug": "removeprotocol-example",
         "text": "Example",
       },
       Object {
@@ -851,6 +876,16 @@ Array [
         "level": 3,
         "slug": "maptouchevent-instance-members",
         "text": "Instance members",
+      },
+      Object {
+        "level": 2,
+        "slug": "maplibrezoomevent",
+        "text": "MapLibreZoomEvent",
+      },
+      Object {
+        "level": 3,
+        "path": "maplibrezoomevent-properties",
+        "text": "Properties",
       },
       Object {
         "level": 2,

--- a/docs/documentation.yml
+++ b/docs/documentation.yml
@@ -9,15 +9,14 @@ toc:
     description: |
       MapLibre GL JS's global properties and options that you can access while initializing your map or accessing information about its status.
     children:
-      - accessToken
-      - baseApiUrl
       - workerCount
       - maxParallelImageRequests
       - supported
-      - version
       - setRTLTextPlugin
       - getRTLTextPluginStatus
       - clearStorage
+      - addProtocol
+      - removeProtocol
       - AnimationOptions
       - CameraOptions
       - PaddingOptions
@@ -90,6 +89,6 @@ toc:
       - Evented
       - MapMouseEvent
       - MapTouchEvent
-      - MapBoxZoomEvent
+      - MapLibreZoomEvent
       - MapDataEvent
       - MapWheelEvent


### PR DESCRIPTION
This pull requests bumps the GL JS submodule to v2.0.1, which includes hopefully the right format for the documentation of the addProtocol and removeProtocol functions.

It also removes include statements for accessToken and other Mapbox-related features that were removed in the TypeScript migrations.
 ﻿
