### PR TITLE
Update downshift

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "babel-eslint": "^10.1.0",
         "check-links": "^1.1.8",
         "documentation": "~13.2.5",
-        "downshift": "^5.4.2",
+        "downshift": "^6.1.7",
         "eslint": "^7.8.1",
         "eslint-config-prettier": "^6.11.0",
         "eslint-plugin-es": "^3.0.1",
@@ -1446,12 +1446,15 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.0.tgz",
+      "integrity": "sha512-etcO/ohMNaNA2UBdaXBBSX/3aEzFMRrVfaPv8Ptc0k+cWpWW0QFiGZ2XnVqQZI1Cf734LbPGmqBKWESfW4x/dQ==",
       "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -8483,9 +8486,9 @@
       "dev": true
     },
     "node_modules/compute-scroll-into-view": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.16.tgz",
-      "integrity": "sha512-a85LHKY81oQnikatZYA90pufpZ6sQx++BoCxOEMsjpZx+ZnaKGQnCyCehTRr/1p9GBIAHTjcU9k71kSYWloLiQ==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
+      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==",
       "dev": true
     },
     "node_modules/concat-map": {
@@ -12763,19 +12766,26 @@
       }
     },
     "node_modules/downshift": {
-      "version": "5.4.7",
-      "resolved": "https://registry.npmjs.org/downshift/-/downshift-5.4.7.tgz",
-      "integrity": "sha512-xaH0RNqwJ5pAsyk9qBmR9XJWmg1OOWMfrhzYv0NH2NjJxn77S3zBcfClw341UfhGyKg5v+qVqg/CQzvAgBNCXQ==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.7.tgz",
+      "integrity": "sha512-cVprZg/9Lvj/uhYRxELzlu1aezRcgPWBjTvspiGTVEU64gF5pRdSRKFVLcxqsZC637cLAGMbL40JavEfWnqgNg==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.10.2",
-        "compute-scroll-into-view": "^1.0.14",
+        "@babel/runtime": "^7.14.8",
+        "compute-scroll-into-view": "^1.0.17",
         "prop-types": "^15.7.2",
-        "react-is": "^16.13.1"
+        "react-is": "^17.0.2",
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "react": ">=16.8.0"
+        "react": ">=16.12.0"
       }
+    },
+    "node_modules/downshift/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
@@ -33391,9 +33401,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
       "dev": true
     },
     "node_modules/tty-browserify": {
@@ -37467,9 +37477,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.0.tgz",
+      "integrity": "sha512-etcO/ohMNaNA2UBdaXBBSX/3aEzFMRrVfaPv8Ptc0k+cWpWW0QFiGZ2XnVqQZI1Cf734LbPGmqBKWESfW4x/dQ==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
@@ -43279,9 +43289,9 @@
       "dev": true
     },
     "compute-scroll-into-view": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.16.tgz",
-      "integrity": "sha512-a85LHKY81oQnikatZYA90pufpZ6sQx++BoCxOEMsjpZx+ZnaKGQnCyCehTRr/1p9GBIAHTjcU9k71kSYWloLiQ==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
+      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==",
       "dev": true
     },
     "concat-map": {
@@ -46619,15 +46629,24 @@
       }
     },
     "downshift": {
-      "version": "5.4.7",
-      "resolved": "https://registry.npmjs.org/downshift/-/downshift-5.4.7.tgz",
-      "integrity": "sha512-xaH0RNqwJ5pAsyk9qBmR9XJWmg1OOWMfrhzYv0NH2NjJxn77S3zBcfClw341UfhGyKg5v+qVqg/CQzvAgBNCXQ==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.7.tgz",
+      "integrity": "sha512-cVprZg/9Lvj/uhYRxELzlu1aezRcgPWBjTvspiGTVEU64gF5pRdSRKFVLcxqsZC637cLAGMbL40JavEfWnqgNg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.2",
-        "compute-scroll-into-view": "^1.0.14",
+        "@babel/runtime": "^7.14.8",
+        "compute-scroll-into-view": "^1.0.17",
         "prop-types": "^15.7.2",
-        "react-is": "^16.13.1"
+        "react-is": "^17.0.2",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
+        }
       }
     },
     "duplexer": {
@@ -63083,9 +63102,9 @@
       }
     },
     "tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
       "dev": true
     },
     "tty-browserify": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babel-eslint": "^10.1.0",
     "check-links": "^1.1.8",
     "documentation": "~13.2.5",
-    "downshift": "^5.4.2",
+    "downshift": "^6.1.7",
     "eslint": "^7.8.1",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-es": "^3.0.1",


### PR DESCRIPTION
Version 6 of downshift has breaking changes regarding TypeScript. We don't use TypeScript, so this should be fine.

https://github.com/downshift-js/downshift/releases/tag/v6.0.0﻿
