### PR TITLE
Update plugins.json - Fix broken link to echarts

### DIFF
--- a/docs/data/plugins.json
+++ b/docs/data/plugins.json
@@ -114,7 +114,7 @@
   "Framework Integrations": {
     "echartslayer": {
       "website": "https://github.com/lzxue/echartLayer",
-      "description": "Provides an [echarts](https://ecomfe.github.io/echarts/index-en.html) integration."
+      "description": "Provides an [echarts](https://echarts.apache.org/en/index.html) integration."
     },
     "wtMapbox": {
       "website": "https://github.com/yvanvds/wtMapbox",


### PR DESCRIPTION
TL;DR Using https://echarts.apache.org/en/index.html rather than broken https://ecomfe.github.io/echarts/index-en.html

https://ecomfe.github.io/echarts/index-en.html returns a 404 error
Clicking "ECharts - 数据可视化图表库" on https://ecomfe.github.io/ leads to https://echarts.baidu.com/ which says:

> ECharts 正在 Apache 开源基金会孵化中，因此域名已不再使用，请访问  echarts.apache.org
> ECharts is now under incubation at the Apache Software Foundation. So this domain name is no longer in
> use. Visit echarts.apache.org please