### PR TITLE
Update build process after GL JS restructuring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
         "@mapbox/rehype-prism": "^0.5.0",
         "classnames": "^2.3.1",
         "fuse.js": "^5.2.3",
-        "rehype-slug": "^2.0.3"
+        "rehype-slug": "^2.0.3",
+        "tsc": "^2.0.4"
       },
       "devDependencies": {
         "@babel/core": "^7.11.6",
@@ -33617,6 +33618,14 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/tsc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/tsc/-/tsc-2.0.4.tgz",
+      "integrity": "sha512-fzoSieZI5KKJVBYGvwbVZs/J5za84f2lSTLPYf6AGiIf43tZ3GNrI1QzTLcjtyDDP4aLxd46RTZq1nQxe7+k5Q==",
+      "bin": {
+        "tsc": "bin/tsc"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
@@ -63488,6 +63497,11 @@
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
       "dev": true
+    },
+    "tsc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/tsc/-/tsc-2.0.4.tgz",
+      "integrity": "sha512-fzoSieZI5KKJVBYGvwbVZs/J5za84f2lSTLPYf6AGiIf43tZ3GNrI1QzTLcjtyDDP4aLxd46RTZq1nQxe7+k5Q=="
     },
     "tsconfig-paths": {
       "version": "3.9.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "scripts": {
     "lint": "eslint --ext .html docs/pages/example --ext .js .",
     "lint-md": "remark docs/pages/",
-    "install-gl-js-deps": "cd maplibre-gl-js/ && npm ci && npm run build-tsc",
+    "install-gl-js-deps": "cd maplibre-gl-js/ && npm ci && npm run tsc --outDir rollup/build/tsc",
     "build-api": "documentation build --pe ts --re ts --re d.ts --github --format json --sort-order alpha --config ./docs/documentation.yml --output docs/components/api.json maplibre-gl-js/src/index.ts",
     "build-images": "mkdir -p docs/img/dist && node docs/bin/build-image-config.js && node docs/bin/appropriate-images.js --all",
     "build-docs": "run-s install-gl-js-deps build-api build-images",
@@ -92,7 +92,8 @@
     "@mapbox/rehype-prism": "^0.5.0",
     "classnames": "^2.3.1",
     "fuse.js": "^5.2.3",
-    "rehype-slug": "^2.0.3"
+    "rehype-slug": "^2.0.3",
+    "tsc": "^2.0.4"
   },
   "jest": {
     "testPathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "scripts": {
     "lint": "eslint --ext .html docs/pages/example --ext .js .",
     "lint-md": "remark docs/pages/",
-    "install-gl-js-deps": "cd maplibre-gl-js/ && npm ci && npm run tsc --outDir rollup/build/tsc",
+    "install-gl-js-deps": "cd maplibre-gl-js/ && npm ci && npx tsc --outDir rollup/build/tsc",
     "build-api": "documentation build --pe ts --re ts --re d.ts --github --format json --sort-order alpha --config ./docs/documentation.yml --output docs/components/api.json maplibre-gl-js/src/index.ts",
     "build-images": "mkdir -p docs/img/dist && node docs/bin/build-image-config.js && node docs/bin/appropriate-images.js --all",
     "build-docs": "run-s install-gl-js-deps build-api build-images",


### PR DESCRIPTION
This pull request updates the build process after restructuring in GL JS where the 2 step build was simplified to a 1 step build.

With this pull request, the docs gets access again to the intermediary .js files in the rollup/build folder. The JavaScript files are 
necessary to parse the style spec correctly.
