### PR TITLE
Fix: In Add 3D Model example, make the 3D layer the topmost layer

### DIFF
--- a/docs/pages/example/add-3d-model.html
+++ b/docs/pages/example/add-3d-model.html
@@ -115,6 +115,6 @@
     };
 
     map.on('style.load', function () {
-        map.addLayer(customLayer, 'road_area_bridge');
+        map.addLayer(customLayer);
     });
 </script>


### PR DESCRIPTION
As seen in partly unrelated [issue](https://github.com/maplibre/maplibre-gl-js/issues/755), new users can be easily confused by the decision in the Add 3D Model example to render the example model below the road network layer.

To improve first impressions, this PR makes the 3D layer the topmost layer.

Before:

https://user-images.githubusercontent.com/1556222/159116367-1f007c6d-3190-43c4-be50-a2d93544fe7f.mp4


After:

https://user-images.githubusercontent.com/1556222/159116384-07aaafd3-3ebc-4a81-80b5-a0fa5b9aca35.mp4


It is good to note this is _not_ a fix for the actual mentioned occlusion issue in the original issue, but a remedy to the implementation of the example.