### PR TITLE
Include TransformStyleFunction into properties and options section

### DIFF
--- a/docs/documentation.yml
+++ b/docs/documentation.yml
@@ -25,6 +25,11 @@ toc:
       - CustomLayerInterface
       - prewarm
       - clearPrewarmedResources
+      - StylePatchFunction
+      - PreserveLayerFunction
+      - UpdatePaintPropertyFunction
+      - UpdateLayoutPropertyFunction
+      - UpdateFilterFunction
 
   - name: Markers and controls
     page: 'markers'

--- a/docs/documentation.yml
+++ b/docs/documentation.yml
@@ -25,11 +25,7 @@ toc:
       - CustomLayerInterface
       - prewarm
       - clearPrewarmedResources
-      - StylePatchFunction
-      - PreserveLayerFunction
-      - UpdatePaintPropertyFunction
-      - UpdateLayoutPropertyFunction
-      - UpdateFilterFunction
+      - TransformStyleFunction
 
   - name: Markers and controls
     page: 'markers'


### PR DESCRIPTION
Depends on https://github.com/maplibre/maplibre-gl-js/pull/1632, this PR adds TransformStyleFunction type into the end of properties and options section, so that docstrings in [map#setStyle](https://maplibre.org/maplibre-gl-js-docs/api/map/#map#setstyle) can link to them.