### PR TITLE
Disable latest-version check to fix CI

### DIFF
--- a/test/latest-version.test.js
+++ b/test/latest-version.test.js
@@ -1,32 +1,32 @@
-const test = require('tape');
-const path = require('path');
-const helpers = require('./helpers');
+// const test = require('tape');
+// const path = require('path');
+// const helpers = require('./helpers');
 
-let tags = [];
+// let tags = [];
 
-async function tagsMatch() {
-    await process.chdir(path.join(process.cwd(), './maplibre-gl-js'));
-    const latest = await helpers.latestStableTag();
-    const current = await helpers.currentTag();
-    if (latest === current) {
-        await process.chdir(path.join(process.cwd(), '..'));
-        return true;
-    } else {
-        await process.chdir(path.join(process.cwd(), '..'));
-        tags.push(latest);
-        tags.push(current);
-        return false;
-    }
-}
-
-test(`Is latest version`, (t) => {
-    tagsMatch().then((res) => {
-        t.ok(
-            res,
-            `MapLibre GL JS submodule is not pinned to the latest stable release version.
-             Latest: ${tags[0]}. Currently checked out: ${tags[1]}.
-            To proceed, pull the latest from publisher-production and merge with "git merge publisher-production" from the feature branch.`
-        );
-        t.end();
-    });
-});
+// async function tagsMatch() {
+//     await process.chdir(path.join(process.cwd(), './maplibre-gl-js'));
+//     const latest = await helpers.latestStableTag();
+//     const current = await helpers.currentTag();
+//     if (latest === current) {
+//         await process.chdir(path.join(process.cwd(), '..'));
+//         return true;
+//     } else {
+//         await process.chdir(path.join(process.cwd(), '..'));
+//         tags.push(latest);
+//         tags.push(current);
+//         return false;
+//     }
+// }
+//
+// test(`Is latest version`, (t) => {
+//     tagsMatch().then((res) => {
+//         t.ok(
+//             res,
+//             `MapLibre GL JS submodule is not pinned to the latest stable release version.
+//              Latest: ${tags[0]}. Currently checked out: ${tags[1]}.
+//             To proceed, pull the latest from publisher-production and merge with "git merge publisher-production" from the feature branch.`
+//         );
+//         t.end();
+//     });
+// });


### PR DESCRIPTION
It's not good that this repo's CI suddenly breaks out of nowhere because of the release cycle of another repo. Also, this will allow us to test that the docs can build pre-release versions of maplibre-gl-js