### PR TITLE
Fix github-pages-deploy-action

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -19,7 +19,7 @@ jobs:
     - run: npm run test
     - run: cp _config.yml _site
     - name: Deploy
-      uses: JamesIves/github-pages-deploy-action@4.4.0
+      uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: gh-pages
         folder: _site


### PR DESCRIPTION
Updating the **JamesIves/github-pages-deploy-action** from @4.1.0 to @4.4.0 broke, because they presumably now want us to simply write @v4