### PR TITLE
Set node to 16.16, because 16.17 breaks

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 16.16
     - run: npm ci
     - run: git submodule update --init
     - run: npm run build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 16.16
     - run: npm ci
     - run: git submodule update --init
     - run: npm run build

--- a/.github/workflows/update-gl-js.yml
+++ b/.github/workflows/update-gl-js.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 16.16
 
     - name: Prepare
       id: prepare


### PR DESCRIPTION
Until we update the submodule, node shouldn't automatically be set to 16.17 by our github actions, as it will break.