### PR TITLE
Fix comment on animated image example

### DIFF
--- a/docs/pages/example/add-image-animated.html
+++ b/docs/pages/example/add-image-animated.html
@@ -9,8 +9,8 @@
 
     var size = 200;
 
-    // implementation of CustomLayerInterface to draw a pulsing dot icon on the map
-    // see https://maplibre.org/maplibre-gl-js-docs/api/properties/#customlayerinterface for more info
+    // implementation of StyleImageInterface to draw a pulsing dot icon on the map
+    // see https://maplibre.org/maplibre-gl-js-docs/api/properties/#styleimageinterface for more info
     var pulsingDot = {
         width: size,
         height: size,


### PR DESCRIPTION
The interface implemented in this example is [StyleImageInterface](https://maplibre.org/maplibre-gl-js-docs/api/properties/#styleimageinterface), not [CustomLayerInterface](https://maplibre.org/maplibre-gl-js-docs/api/properties/#customlayerinterface).