### PR TITLE
update dem info to include Terrarium

### DIFF
--- a/docs/pages/style-spec/sources.md
+++ b/docs/pages/style-spec/sources.md
@@ -145,6 +145,7 @@ A raster DEM source. Only supports [Mapbox Terrain RGB](https://blog.mapbox.com/
 ```json
 "maplibre-terrain-rgb": {
     "type": "raster-dem",
+    "encoding": "mapbox",
     "tiles": [
         "http://a.example.com/dem-tiles/{z}/{x}/{y}.png"
     ],

--- a/docs/pages/style-spec/sources.md
+++ b/docs/pages/style-spec/sources.md
@@ -140,7 +140,7 @@ https://github.com/maplibre/maplibre-gl-js/blob/main/src/style-spec/reference/v8
 
 ## raster-dem
 
-A raster DEM source. Only supports [Mapbox Terrain RGB](https://blog.mapbox.com/global-elevation-data-6689f1d0ba65):
+A raster DEM source. Only supports Mapbox Terrain RGB and Mapzen Terrarium tiles.
 
 ```json
 "maplibre-terrain-rgb": {

--- a/docs/pages/style-spec/sources.md
+++ b/docs/pages/style-spec/sources.md
@@ -69,7 +69,6 @@ A vector tile source. Tiles must be in [Mapbox Vector Tile format](https://docs.
 ```json
 "maplibre-streets": {
     "type": "vector",
-    "encoding": "mapbox",
     "tiles": [
         "http://a.example.com/tiles/{z}/{x}/{y}.pbf"
     ],

--- a/docs/pages/style-spec/sources.md
+++ b/docs/pages/style-spec/sources.md
@@ -69,6 +69,7 @@ A vector tile source. Tiles must be in [Mapbox Vector Tile format](https://docs.
 ```json
 "maplibre-streets": {
     "type": "vector",
+    "encoding": "mapbox",
     "tiles": [
         "http://a.example.com/tiles/{z}/{x}/{y}.pbf"
     ],

--- a/docs/pages/style-spec/sources.md
+++ b/docs/pages/style-spec/sources.md
@@ -140,7 +140,7 @@ https://github.com/maplibre/maplibre-gl-js/blob/main/src/style-spec/reference/v8
 
 ## raster-dem
 
-A raster DEM source. Only supports Mapbox Terrain RGB and Mapzen Terrarium tiles.
+A raster DEM source. Only supports [Mapbox Terrain RGB](https://blog.mapbox.com/global-elevation-data-6689f1d0ba65) and Mapzen Terrarium tiles.
 
 ```json
 "maplibre-terrain-rgb": {


### PR DESCRIPTION
This is in relation to https://github.com/maplibre/maplibre-gl-js/issues/2137

This adds Terrarium to the list of supported dem types. the text was copied from layers.md (hillshade)