### PR TITLE
Update dependencies docs

### DIFF
--- a/docs/pages/api/index.md
+++ b/docs/pages/api/index.md
@@ -106,17 +106,13 @@ Note too that if the CSS isn't available by the first render, as soon as the CSS
 
 The dependencies for MapLibre GL JS (`.js` & `.css`) are distributed via [UNPKG.com](https://unpkg.com).  UNPKG can distribute a fixed version, a [semver range](https://semver.org/), a tag, or omit the version/tag entirely to use the `latest` tag.
 
-You can view a listing of all the files in the MapLibre GL JS package by appending a `/` at the end of the MapLibre slug.  This is useful to review other revisions or older `CHANGELOG`s.
-
-* [https://unpkg.com/maplibre-gl/](https://unpkg.com/maplibre-gl/)
+You can view a listing of all the files in the MapLibre GL JS package by appending a `/` at the end of the MapLibre slug.  This is useful to review other revisions or to review the files at UNPKG or the LICENSE.  See <https://unpkg.com/maplibre-gl/>
 
 *Examples*
 
 | Use Case  | `.js` | `.css` |
 | :------- | :---: | :----: |
-| `latest` | [https://unpkg.com/maplibre-gl/dist/maplibre-gl.js](https://unpkg.com/maplibre-gl/dist/maplibre-gl.js) | [https://unpkg.com/maplibre-gl/dist/maplibre-gl.css](https://unpkg.com/maplibre-gl/dist/maplibre-gl.css) |
-| Use a fixed version `1.14.0` | [https://unpkg.com/maplibre-gl@1.14.0/dist/maplibre-gl.js](https://unpkg.com/maplibre-gl@1.14.0/dist/maplibre-gl.js) | [https://unpkg.com/maplibre-gl@1.14.0/dist/maplibre-gl.css](https://unpkg.com/maplibre-gl@1.14.0/dist/maplibre-gl.css) |
-| Use at least `1.14.x` | [https://unpkg.com/maplibre-gl@^1.14/dist/maplibre-gl.js](https://unpkg.com/maplibre-gl@^1.14/dist/maplibre-gl.js) | [https://unpkg.com/maplibre-gl@^1.14/dist/maplibre-gl.css](https://unpkg.com/maplibre-gl@^1.14/dist/maplibre-gl.css) |
-| Return metadata as JSON on `latest` to review `lastModified` & `size`. | [https://unpkg.com/maplibre-gl/dist/maplibre-gl.js?meta](https://unpkg.com/maplibre-gl/dist/maplibre-gl.js?meta) | [https://unpkg.com/maplibre-gl/dist/maplibre-gl.css?meta](https://unpkg.com/maplibre-gl/dist/maplibre-gl.css?meta)  |
-| `CHANGELOG.md` for `latest` | [https://unpkg.com/browse/maplibre-gl/CHANGELOG.md](https://unpkg.com/browse/maplibre-gl/CHANGELOG.md) |  |
-| `LICENSE.txt` for `latest` | [https://unpkg.com/browse/maplibre-gl/LICENSE.txt](https://unpkg.com/browse/maplibre-gl/LICENSE.txt) |  |
+| `latest` |{{<Copyable lang="html">{`https://unpkg.com/maplibre-gl/dist/maplibre-gl.js`}</Copyable>}} | {{<Copyable lang="html">{`https://unpkg.com/maplibre-gl/dist/maplibre-gl.css`}</Copyable>}} |
+| Use a fixed version | {{<Copyable lang="html">{`${urls.js()}`}</Copyable>}} | {{<Copyable lang="html">{`${urls.css()}`}</Copyable>}} | 
+| Use at least `2.4.x` | <https://unpkg.com/maplibre-gl@^2.4/dist/maplibre-gl.js> | <https://unpkg.com/maplibre-gl@^2.4/dist/maplibre-gl.css> |
+| metadata: `size` | <https://unpkg.com/maplibre-gl/dist/maplibre-gl.js?meta> | <https://unpkg.com/maplibre-gl/dist/maplibre-gl.css?meta> |

--- a/docs/pages/style-spec/layers.md
+++ b/docs/pages/style-spec/layers.md
@@ -33,7 +33,7 @@ Except for layers of the <var>background</var> type, each layer needs to refer t
 START GENERATED CONTENT:
 Content in this section is generated directly using the MapLibre Style
 Specification. To update any content displayed in this section, make edits to:
-https://github.com/maplibre/maplibre-gl-js/blob/main/src/style-spec/reference/v8.json.
+https://github.com/maplibre/maplibre-gl-style-spec/blob/main/src/reference/v8.json
 -->
 {{ <Items entry={ref.layer} />}}
 <!-- END GENERATED CONTENT -->
@@ -53,7 +53,7 @@ _Paint properties_ are applied later in the rendering process. Paint properties 
 START GENERATED CONTENT:
 Content in this section is generated directly using the MapLibre Style
 Specification. To update any content displayed in this section, make edits to:
-https://github.com/maplibre/maplibre-gl-js/blob/main/src/style-spec/reference/v8.json.
+https://github.com/maplibre/maplibre-gl-style-spec/blob/main/src/reference/v8.json
 -->
 
 ## background

--- a/docs/pages/style-spec/light.md
+++ b/docs/pages/style-spec/light.md
@@ -27,7 +27,7 @@ A style's `light` property provides a global light source for that style. Since 
 START GENERATED CONTENT:
 Content in this section is generated directly using the MapLibre Style
 Specification. To update any content displayed in this section, make edits to:
-https://github.com/maplibre/maplibre-gl-js/blob/main/src/style-spec/reference/v8.json.
+https://github.com/maplibre/maplibre-gl-style-spec/blob/main/src/reference/v8.json
 -->
 {{ <Items headingLevel='2' entry={ref.light} /> }}
 <!-- END GENERATED CONTENT -->

--- a/docs/pages/style-spec/root.md
+++ b/docs/pages/style-spec/root.md
@@ -30,7 +30,7 @@ Root level properties of a MapLibre style specify the map's layers, tile sources
 START GENERATED CONTENT:
 Content in this section is generated directly using the MapLibre Style
 Specification. To update any content displayed in this section, make edits to:
-https://github.com/maplibre/maplibre-gl-js/blob/main/src/style-spec/reference/v8.json.
+https://github.com/maplibre/maplibre-gl-style-spec/blob/main/src/reference/v8.json
 -->
 {{<Items headingLevel='2' entry={ref.$root} />}}
 <!-- END GENERATED CONTENT -->

--- a/docs/pages/style-spec/sources.md
+++ b/docs/pages/style-spec/sources.md
@@ -79,7 +79,7 @@ A vector tile source. Tiles must be in [Mapbox Vector Tile format](https://docs.
 START GENERATED CONTENT:
 Content in this section is generated directly using the MapLibre Style
 Specification. To update any content displayed in this section, make edits to:
-https://github.com/maplibre/maplibre-gl-js/blob/main/src/style-spec/reference/v8.json.
+https://github.com/maplibre/maplibre-gl-style-spec/blob/main/src/reference/v8.json
 -->
 {{<Items headingLevel='3' entry={ref.source_vector} section="vector" />}}
 <!-- END GENERATED CONTENT -->
@@ -118,7 +118,7 @@ A raster tile source.
 START GENERATED CONTENT:
 Content in this section is generated directly using the MapLibre Style
 Specification. To update any content displayed in this section, make edits to:
-https://github.com/maplibre/maplibre-gl-js/blob/main/src/style-spec/reference/v8.json.
+https://github.com/maplibre/maplibre-gl-style-spec/blob/main/src/reference/v8.json
 -->
 {{<Items headingLevel='3' entry={ref.source_raster} section="raster" />}}
 <!-- END GENERATED CONTENT -->
@@ -156,7 +156,7 @@ A raster DEM source. Only supports [Mapbox Terrain RGB](https://blog.mapbox.com/
 START GENERATED CONTENT:
 Content in this section is generated directly using the MapLibre Style
 Specification. To update any content displayed in this section, make edits to:
-https://github.com/maplibre/maplibre-gl-js/blob/main/src/style-spec/reference/v8.json.
+https://github.com/maplibre/maplibre-gl-style-spec/blob/main/src/reference/v8.json
 -->
 {{<Items headingLevel='3' entry={ref.source_raster_dem} section="raster-dem" />}}
 <!-- END GENERATED CONTENT -->
@@ -206,7 +206,7 @@ This example of a GeoJSON source refers to an external GeoJSON document via its 
 START GENERATED CONTENT:
 Content in this section is generated directly using the MapLibre Style
 Specification. To update any content displayed in this section, make edits to:
-https://github.com/maplibre/maplibre-gl-js/blob/main/src/style-spec/reference/v8.json.
+https://github.com/maplibre/maplibre-gl-style-spec/blob/main/src/reference/v8.json
 -->
 {{<Items headingLevel='3' entry={ref.source_geojson} section="geojson" />}}
 <!-- END GENERATED CONTENT -->
@@ -258,7 +258,7 @@ The `"coordinates"` array contains `[longitude, latitude]` pairs for the image c
 START GENERATED CONTENT:
 Content in this section is generated directly using the MapLibre Style
 Specification. To update any content displayed in this section, make edits to:
-https://github.com/maplibre/maplibre-gl-js/blob/main/src/style-spec/reference/v8.json.
+https://github.com/maplibre/maplibre-gl-style-spec/blob/main/src/reference/v8.json
 -->
 {{<Items headingLevel='3' entry={ref.source_image} section="image" />}}
 <!-- END GENERATED CONTENT -->
@@ -304,7 +304,7 @@ The `"coordinates"` array contains `[longitude, latitude]` pairs for the video c
 START GENERATED CONTENT:
 Content in this section is generated directly using the MapLibre Style
 Specification. To update any content displayed in this section, make edits to:
-https://github.com/maplibre/maplibre-gl-js/blob/main/src/style-spec/reference/v8.json.
+https://github.com/maplibre/maplibre-gl-style-spec/blob/main/src/reference/v8.json
 -->
 {{<Items headingLevel='3' entry={ref.source_video} section="video" />}}
 <!-- END GENERATED CONTENT -->

--- a/docs/pages/style-spec/transition.md
+++ b/docs/pages/style-spec/transition.md
@@ -39,7 +39,7 @@ Any transitionable layer property, marked by {{<Icon
 START GENERATED CONTENT:
 Content in this section is generated directly using the MapLibre Style
 Specification. To update any content displayed in this section, make edits to:
-https://github.com/maplibre/maplibre-gl-js/blob/main/src/style-spec/reference/v8.json.
+https://github.com/maplibre/maplibre-gl-style-spec/blob/main/src/reference/v8.json
 -->
 {{<Items headingLevel='2' entry={ref.transition} />}}
 <!-- END GENERATED CONTENT -->


### PR DESCRIPTION

1. 
- [x] Following along https://github.com/maplibre/maplibre-gl-style-spec/pull/23, update hardcoded links (the docs said how to update the docs based on `v8.json`, but v8 has moved).

---

2. 
- [x] Refactor how the UNPKG links are displayed for the [dependencies](https://maplibre.org/maplibre-gl-js-docs/api/#dependencies) section.  _I wrote this section for our Technical Writing team in the early days, and it needed to be refreshed_.  Tested; see screen cap.

<img width="61.8%" alt="update-dependencies-docs" src="https://user-images.githubusercontent.com/118112/222028022-0fc036bb-15a9-4b26-8ca2-f07e2917dbe9.png">
