### PR TITLE
Fix "Can't resolve '@maplibre/maplibre-gl-style-spec/package.json'"

### DIFF
--- a/docs/components/page-shell.js
+++ b/docs/components/page-shell.js
@@ -23,7 +23,7 @@ import Browser from '@mapbox/dr-ui/browser';
 import redirectApiRef from '../util/api-ref-redirect';
 import classnames from 'classnames';
 import { version } from '../../node_modules/maplibre-gl/package.json';
-import { version as styleSpecVersion } from '@maplibre/maplibre-gl-style-spec/package.json';
+import { version as styleSpecVersion } from '../../node_modules/@maplibre/maplibre-gl-style-spec/package.json';
 
 import slug from 'slugg';
 


### PR DESCRIPTION
After pulling latest main, I see the following error on `npm run start`:
```
./docs/components/page-shell.js
Module not found: Can't resolve '@maplibre/maplibre-gl-style-spec/package.json' in '/home/ailanthus/Documents/maplibre-gl-js-docs/docs/components'
```
This change resolves the issue.