### PR TITLE
Added maplibre-layers-event-propagator plugin

### DIFF
--- a/docs/data/plugins.json
+++ b/docs/data/plugins.json
@@ -190,6 +190,10 @@
     "maplibregl-mapbox-request-transformer": {
       "website": "https://github.com/rowanwins/maplibregl-mapbox-request-transformer",
       "description": "This library provides a request transforming function enabling the consumption of MapboxGL Styles in MapLibreGL."
+    },
+    "maplibre-layers-event-propagator": {
+      "website": "https://github.com/marucjmar/any-routing/tree/master/packages/maplibre-layers-event-propagator",
+      "description": "Plugin to stop event propagation between layers."
     }
   },
   "Development Tools": {


### PR DESCRIPTION
Hi,

I created an add-on that allows stop the propagation(with immediatePropagation support) of events between layers. [Repo](https://github.com/marucjmar/any-routing/tree/master/packages/maplibre-layers-event-propagator)

What do you think about putting the code from this plugin into the library(maplibre-gl-js) code? 