### PR TITLE
Point links to maplibre-style-spec docs

### DIFF
--- a/batfish.config.js
+++ b/batfish.config.js
@@ -11,7 +11,7 @@ const {
 const addPages = [
     {
         title: 'Style Specification',
-        path: 'https://maplibre.org/maplibre-style/',
+        path: 'https://maplibre.org/maplibre-style-spec/',
         navOrder: 5
     }
 ];

--- a/docs/data/plugins.json
+++ b/docs/data/plugins.json
@@ -164,7 +164,7 @@
     },
     "expression-jamsession": {
       "website": "https://github.com/mapbox/expression-jamsession/",
-      "description": "Converts [Mapbox Studio formulas](https://www.mapbox.com/help/studio-manual-styles/#use-a-formula) into [expressions](https://maplibre.org/maplibre-style/expressions/)."
+      "description": "Converts [Mapbox Studio formulas](https://www.mapbox.com/help/studio-manual-styles/#use-a-formula) into [expressions](https://maplibre.org/maplibre-style-spec/expressions/)."
     },
     "simplespec-to-gl-style": {
       "website": "https://github.com/mapbox/simplespec-to-gl-style",

--- a/docs/documentation.yml
+++ b/docs/documentation.yml
@@ -70,7 +70,7 @@ toc:
   - name: Sources
     page: 'sources'
     description: |
-      The source types MapLibre GL JS can handle in addition to the ones described in the [MapLibre Style documentation](https://maplibre.org/maplibre-style).
+      The source types MapLibre GL JS can handle in addition to the ones described in the [MapLibre Style documentation](https://maplibre.org/maplibre-style-spec).
     children:
       - GeoJSONSource
       - VideoSource

--- a/docs/pages/api/index.md
+++ b/docs/pages/api/index.md
@@ -28,7 +28,7 @@ overviewHeader:
   # version="" version is set dynamically in page-shell.js
 ---
 
-MapLibre GL JS is a JavaScript library that uses WebGL to render interactive maps from vector tiles and [MapLibre styles](https://maplibre.org/maplibre-style). It is part of the [MapLibre GL ecosystem](https://github.com/maplibre).
+MapLibre GL JS is a JavaScript library that uses WebGL to render interactive maps from vector tiles and [MapLibre styles](https://maplibre.org/maplibre-style-spec). It is part of the [MapLibre GL ecosystem](https://github.com/maplibre).
 
 
 ## Quickstart
@@ -61,7 +61,7 @@ This documentation is divided into several sections:
 * [**Markers and controls**](https://maplibre.org/maplibre-gl-js-docs/api/markers/). This section describes the user interface elements that you can add to your map. The items in this section exist outside of the map's `canvas` element.
 * [**Geography and geometry**](https://maplibre.org/maplibre-gl-js-docs/api/geography/). This section includes general utilities and types that relate to working with and manipulating geographic information or geometries.
 * [**User interaction handlers**](https://maplibre.org/maplibre-gl-js-docs/api/handlers/). The items in this section relate to the ways in which the map responds to user input.
-* [**Sources**](https://maplibre.org/maplibre-gl-js-docs/api/sources/). This section describes the source types MapLibre GL JS can handle besides the ones described in the [MapLibre Style Specification](https://maplibre.org/maplibre-style/).
+* [**Sources**](https://maplibre.org/maplibre-gl-js-docs/api/sources/). This section describes the source types MapLibre GL JS can handle besides the ones described in the [MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/).
 * [**Events**](https://maplibre.org/maplibre-gl-js-docs/api/events/). This section describes the different types of events that MapLibre GL JS can raise.
 
 Each section describes classes or objects as well as their **properties**, **parameters**, **instance members**, and associated **events**. Many sections also include inline code examples and related resources.

--- a/docs/pages/example/3d-buildings.md
+++ b/docs/pages/example/3d-buildings.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './3d-buildings.html';"
 ---
 
-Use [extrusions](https://maplibre.org/maplibre-style/layers/#fill-extrusion) to display buildings' height in 3D.
+Use [extrusions](https://maplibre.org/maplibre-style-spec/layers/#fill-extrusion) to display buildings' height in 3D.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/3d-extrusion-floorplan.html
+++ b/docs/pages/example/3d-extrusion-floorplan.html
@@ -52,7 +52,7 @@
             'source': 'floorplan',
             'paint': {
                 // See the MapLibre Style Specification for details on data expressions.
-                // https://maplibre.org/maplibre-style/expressions/
+                // https://maplibre.org/maplibre-style-spec/expressions/
 
                 // Get the fill-extrusion-color from the source 'color' property.
                 'fill-extrusion-color': ['get', 'color'],

--- a/docs/pages/example/3d-extrusion-floorplan.md
+++ b/docs/pages/example/3d-extrusion-floorplan.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './3d-extrusion-floorplan.html';"
 ---
 
-Create a 3D indoor map with the [`fill-extrude-height`](https://maplibre.org/maplibre-style/layers/#paint-fill-extrusion-fill-extrusion-height) paint property.
+Create a 3D indoor map with the [`fill-extrude-height`](https://maplibre.org/maplibre-style-spec/layers/#paint-fill-extrusion-fill-extrusion-height) paint property.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/add-image.md
+++ b/docs/pages/example/add-image.md
@@ -17,6 +17,6 @@ prependJs:
 - "import html from './add-image.html';"
 ---
 
-Add an icon to the map from an external URL and use it in a [symbol layer](https://maplibre.org/maplibre-style/layers/#symbol).
+Add an icon to the map from an external URL and use it in a [symbol layer](https://maplibre.org/maplibre-style-spec/layers/#symbol).
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/animate-images.md
+++ b/docs/pages/example/animate-images.md
@@ -17,6 +17,6 @@ prependJs:
 - "import html from './animate-images.html';"
 ---
 
-Use a series of [image sources](https://maplibre.org/maplibre-style/sources/#image) to create an animation.
+Use a series of [image sources](https://maplibre.org/maplibre-style-spec/sources/#image) to create an animation.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/center-on-symbol.md
+++ b/docs/pages/example/center-on-symbol.md
@@ -17,6 +17,6 @@ prependJs:
 - "import html from './center-on-symbol.html';"
 ---
 
-Use events and [`flyTo`](https://maplibre.org/maplibre-gl-js-docs/api/map/#map#flyto) to center the map on a [`symbol`](https://maplibre.org/maplibre-style/layers/#symbol).
+Use events and [`flyTo`](https://maplibre.org/maplibre-gl-js-docs/api/map/#map#flyto) to center the map on a [`symbol`](https://maplibre.org/maplibre-style-spec/layers/#symbol).
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/change-building-color-based-on-zoom-level.md
+++ b/docs/pages/example/change-building-color-based-on-zoom-level.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './change-building-color-based-on-zoom-level.html';"
 ---
 
-Use the [`interpolate` expression](https://maplibre.org/maplibre-style/expressions/#interpolate) to ease-in the building layer and smoothly fade from one color to the next.
+Use the [`interpolate` expression](https://maplibre.org/maplibre-style-spec/expressions/#interpolate) to ease-in the building layer and smoothly fade from one color to the next.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/change-case-of-labels.md
+++ b/docs/pages/example/change-case-of-labels.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './change-case-of-labels.html';"
 ---
 
-Use the [`upcase`](https://maplibre.org/maplibre-style/expressions/#upcase) and [`downcase`](https://maplibre.org/maplibre-style/expressions/#downcase) expressions to change the case of labels.
+Use the [`upcase`](https://maplibre.org/maplibre-style-spec/expressions/#upcase) and [`downcase`](https://maplibre.org/maplibre-style-spec/expressions/#downcase) expressions to change the case of labels.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/cluster.html
+++ b/docs/pages/example/cluster.html
@@ -28,7 +28,7 @@
             source: 'earthquakes',
             filter: ['has', 'point_count'],
             paint: {
-                // Use step expressions (https://maplibre.org/maplibre-style/#expressions-step)
+                // Use step expressions (https://maplibre.org/maplibre-style-spec/#expressions-step)
                 // with three steps to implement three types of circles:
                 //   * Blue, 20px circles when point count is less than 100
                 //   * Yellow, 30px circles when point count is between 100 and 750

--- a/docs/pages/example/data-driven-lines.html
+++ b/docs/pages/example/data-driven-lines.html
@@ -76,7 +76,7 @@
             'source': 'lines',
             'paint': {
                 'line-width': 3,
-                // Use a get expression (https://maplibre.org/maplibre-style/expressions/#get)
+                // Use a get expression (https://maplibre.org/maplibre-style-spec/expressions/#get)
                 // to set the line-color to a feature property value.
                 'line-color': ['get', 'color']
             }

--- a/docs/pages/example/data-driven-lines.md
+++ b/docs/pages/example/data-driven-lines.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './data-driven-lines.html';"
 ---
 
-Create a visualization with a data expression for [`line-color`](https://maplibre.org/maplibre-style/layers/#paint-line-line-color).
+Create a visualization with a data expression for [`line-color`](https://maplibre.org/maplibre-style-spec/layers/#paint-line-line-color).
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/display-and-style-rich-text-labels.md
+++ b/docs/pages/example/display-and-style-rich-text-labels.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './display-and-style-rich-text-labels.html';"
 ---
 
-Use the [`format` expression](https://maplibre.org/maplibre-style/expressions/#types-format) to display country labels in both English and in the local language.
+Use the [`format` expression](https://maplibre.org/maplibre-style-spec/expressions/#types-format) to display country labels in both English and in the local language.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/fallback-image.md
+++ b/docs/pages/example/fallback-image.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './fallback-image.html';"
 ---
 
-Use a [`coalesce`](https://maplibre.org/maplibre-style/expressions/#coalesce) expression to display another image when a requested image is not available.
+Use a [`coalesce`](https://maplibre.org/maplibre-style-spec/expressions/#coalesce) expression to display another image when a requested image is not available.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/fill-pattern.md
+++ b/docs/pages/example/fill-pattern.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './fill-pattern.html';"
 ---
 
-Use [`fill-pattern`](https://maplibre.org/maplibre-style/layers/#paint-fill-fill-pattern) to draw a polygon from a repeating image pattern.
+Use [`fill-pattern`](https://maplibre.org/maplibre-style-spec/layers/#paint-fill-fill-pattern) to draw a polygon from a repeating image pattern.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/filter-markers-by-input.md
+++ b/docs/pages/example/filter-markers-by-input.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './filter-markers-by-input.html';"
 ---
 
-Filter [symbols](https://maplibre.org/maplibre-style/layers/#symbol) by icon name by typing in a text input.
+Filter [symbols](https://maplibre.org/maplibre-style-spec/layers/#symbol) by icon name by typing in a text input.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/filter-markers.md
+++ b/docs/pages/example/filter-markers.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './filter-markers.html';"
 ---
 
-Filter a set of [symbols](https://maplibre.org/maplibre-style/layers/#symbol) based on a property value in the data.
+Filter a set of [symbols](https://maplibre.org/maplibre-style-spec/layers/#symbol) based on a property value in the data.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/geojson-line.md
+++ b/docs/pages/example/geojson-line.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './geojson-line.html';"
 ---
 
-Add a GeoJSON line to a map using [`addSource`](https://maplibre.org/maplibre-gl-js-docs/api/map/#map#addsource), then style it using [`addLayer`](https://maplibre.org/maplibre-gl-js-docs/api/map/#map#addlayer)’s [`paint`](https://maplibre.org/maplibre-style/layers/#line) properties.
+Add a GeoJSON line to a map using [`addSource`](https://maplibre.org/maplibre-gl-js-docs/api/map/#map#addsource), then style it using [`addLayer`](https://maplibre.org/maplibre-gl-js-docs/api/map/#map#addlayer)’s [`paint`](https://maplibre.org/maplibre-style-spec/layers/#line) properties.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/geojson-polygon.md
+++ b/docs/pages/example/geojson-polygon.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './geojson-polygon.html';"
 ---
 
-Style a polygon with the [fill layer](https://maplibre.org/maplibre-style/layers/#fill) type.
+Style a polygon with the [fill layer](https://maplibre.org/maplibre-style-spec/layers/#fill) type.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/heatmap-layer.md
+++ b/docs/pages/example/heatmap-layer.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './heatmap-layer.html';"
 ---
 
-Visualize earthquake frequency by location using a [heatmap layer](https://maplibre.org/maplibre-style/layers/#heatmap).
+Visualize earthquake frequency by location using a [heatmap layer](https://maplibre.org/maplibre-style-spec/layers/#heatmap).
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/line-across-180th-meridian.md
+++ b/docs/pages/example/line-across-180th-meridian.md
@@ -17,6 +17,6 @@ prependJs:
 - "import html from './line-across-180th-meridian.html';"
 ---
 
-Draw a line across the 180th meridian using a [GeoJSON source](https://maplibre.org/maplibre-style/sources/#geojson).
+Draw a line across the 180th meridian using a [GeoJSON source](https://maplibre.org/maplibre-style-spec/sources/#geojson).
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/line-gradient.md
+++ b/docs/pages/example/line-gradient.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './line-gradient.html';"
 ---
 
-Use the [`line-gradient`](https://maplibre.org/maplibre-style/layers/#paint-line-line-gradient) paint property and an expression to visualize distance from the starting point of a line.
+Use the [`line-gradient`](https://maplibre.org/maplibre-style-spec/layers/#paint-line-line-gradient) paint property and an expression to visualize distance from the starting point of a line.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/live-geojson.md
+++ b/docs/pages/example/live-geojson.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './live-geojson.html';"
 ---
 
-Use realtime GeoJSON data streams to move a [`symbol`](https://maplibre.org/maplibre-style/layers/#symbol) on your map.
+Use realtime GeoJSON data streams to move a [`symbol`](https://maplibre.org/maplibre-style-spec/layers/#symbol) on your map.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/variable-label-placement.md
+++ b/docs/pages/example/variable-label-placement.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './variable-label-placement.html';"
 ---
 
-Use [`text-variable-anchor`](https://maplibre.org/maplibre-style/layers/#layout-symbol-text-variable-anchor) to allow high priority labels to shift position to stay on the map.
+Use [`text-variable-anchor`](https://maplibre.org/maplibre-style-spec/layers/#layout-symbol-text-variable-anchor) to allow high priority labels to shift position to stay on the map.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/vector-source.md
+++ b/docs/pages/example/vector-source.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './vector-source.html';"
 ---
 
-Add a [vector source](https://maplibre.org/maplibre-style/sources/#vector) to a map.
+Add a [vector source](https://maplibre.org/maplibre-style-spec/sources/#vector) to a map.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/visualize-population-density.md
+++ b/docs/pages/example/visualize-population-density.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './visualize-population-density.html';"
 ---
 
-Use a [variable binding expression](https://maplibre.org/maplibre-style/expressions/#variable-binding) to calculate and display population density.
+Use a [variable binding expression](https://maplibre.org/maplibre-style-spec/expressions/#variable-binding) to calculate and display population density.
 
 {{ <Example html={html} {...this.props} /> }}

--- a/docs/pages/example/wms.html
+++ b/docs/pages/example/wms.html
@@ -11,7 +11,7 @@
         map.addSource('wms-test-source', {
             'type': 'raster',
             // use the tiles option to specify a WMS tile source URL
-            // https://maplibre.org/maplibre-style/sources/
+            // https://maplibre.org/maplibre-style-spec/sources/
             'tiles': [
                 'https://img.nj.gov/imagerywms/Natural2015?bbox={bbox-epsg-3857}&format=image/png&service=WMS&version=1.1.1&request=GetMap&srs=EPSG:3857&transparent=true&width=256&height=256&layers=Natural2015'
             ],

--- a/docs/pages/example/wms.md
+++ b/docs/pages/example/wms.md
@@ -16,6 +16,6 @@ prependJs:
 - "import html from './wms.html';"
 ---
 
-Add an external [Web Map Service raster layer](https://www.ogc.org/standards/wms) to the map using [`addSource`](https://maplibre.org/maplibre-gl-js-docs/api/map/#map#addsource)'s [`tiles`](https://maplibre.org/maplibre-style/sources/#raster-tiles) option.
+Add an external [Web Map Service raster layer](https://www.ogc.org/standards/wms) to the map using [`addSource`](https://maplibre.org/maplibre-gl-js-docs/api/map/#map#addsource)'s [`tiles`](https://maplibre.org/maplibre-style-spec/sources/#raster-tiles) option.
 
 {{ <Example html={html} {...this.props} /> }}


### PR DESCRIPTION
maplibre-style is renamed to maplibre-style-spec, so this updated the links.