### PR TITLE
Add maplibre-contour to plugins

### DIFF
--- a/docs/data/plugins.json
+++ b/docs/data/plugins.json
@@ -107,6 +107,10 @@
     "flowmap.blue": {
       "website": "https://github.com/ilyabo/flowmap.blue",
       "description": "Render a geographic flow map visualization from a spreadsheet published on Google Sheets."
+    },
+    "maplibre-contour": {
+      "website": "https://github.com/onthegomap/maplibre-contour",
+      "description": "Adds elevation contour lines to a map from raster-dem tiles."
     }
   },
   "Layer Types": {

--- a/docs/pages/example/contour-lines.md
+++ b/docs/pages/example/contour-lines.md
@@ -1,6 +1,6 @@
 ---
 title: Add Contour Lines
-description: Add contour lines to your map from a raster-dem source
+description: Add contour lines to your map from a raster-dem source.
 topics:
     - Layers
 thumbnail: contour-lines


### PR DESCRIPTION
Add https://github.com/onthegomap/maplibre-contour to the plugins page, and also fix punctuation on the examples page.