### PR TITLE
Add Terra Draw as a plugin

### DIFF
--- a/docs/data/plugins.json
+++ b/docs/data/plugins.json
@@ -25,6 +25,10 @@
       "description": "Adds support for drawing and editing features on maps.",
       "example": "mapbox-gl-draw"
     },
+    "terra-draw": {
+      "website": "https://github.com/JamesLMilner/terra-draw",
+      "description": "Provides a MapLibre GL JS adapter to allow creation, selection and editing of geometries",
+     },
     "mapbox-gl-elevation": {
       "website": "https://github.com/watergis/mapbox-gl-elevation",
       "description": "Adds a control to retrieve altitude from terrain RGB tilesets."


### PR DESCRIPTION
A PR to add [terra-draw](https://www.github.com/JamesLMilner/terra-draw) to the plugin page. Terra Draw is a library to allow drawing functionality on maps.